### PR TITLE
refactor: improve JSDoc and add hex conversion utilities

### DIFF
--- a/src/hash.ts
+++ b/src/hash.ts
@@ -65,8 +65,7 @@ const bigIntToArray = (value: bigint): Uint8Array => {
   // length = value.toString(2).length / 2
   const length = Math.ceil(value.toString(10).length / 2)
 
-  console.log('length', length)
-  const byteArray = new Uint8Array(length) // 256 bits = 32 bytes
+  const byteArray = new Uint8Array(length)
   for (let i = 0; i < byteArray.length; i++) {
     byteArray[i] = Number(value & 0xffn) // Extract last 8 bits
     value >>= 8n // Shift right by 8 bits
@@ -116,4 +115,34 @@ const xorBytesInPlace = (
   }
 }
 
-export { xorBytesInPlace, bigIntToArray, bigintToUint8Array, encodeBytes, uint8ArrayToBigInt, sha512HMAC, hexToArray }
+/**
+ * Converts a Uint8Array to a hexadecimal string representation.
+ * @param bytes - The Uint8Array to convert
+ * @param prefix - Whether to include '0x' prefix (default: true)
+ * @returns A hexadecimal string
+ */
+const uint8ArrayToHex = (bytes: Uint8Array, prefix: boolean = true): string => {
+  const hex = Array.from(bytes)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+  return prefix ? '0x' + hex : hex
+}
+
+/**
+ * Converts a hex string to Uint8Array with proper validation.
+ * @param hex - The hex string to convert (with or without 0x prefix)
+ * @returns The converted Uint8Array
+ * @throws {Error} If hex string is invalid
+ */
+const hexToUint8Array = (hex: string): Uint8Array => {
+  const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex
+  if (cleanHex.length % 2 !== 0) {
+    throw new Error(`Hex string must have even length. Got: ${hex}`)
+  }
+  if (!/^[0-9a-fA-F]*$/.test(cleanHex)) {
+    throw new Error(`Invalid hex string: ${hex}`)
+  }
+  return hexToArray(cleanHex)
+}
+
+export { xorBytesInPlace, bigIntToArray, bigintToUint8Array, encodeBytes, uint8ArrayToBigInt, sha512HMAC, hexToArray, uint8ArrayToHex, hexToUint8Array }

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -24,10 +24,11 @@ const CURVE_L_BYTES = bigintToUint8Array(CURVE_L)
 // ed25519.getPublicKey(privKey);
 // ed25519.sign(msg, privKey);
 // ed25519.verify(signature, msg, pubKey);
+
 /**
- *1
- * @param m a
- * @returns a
+ * SHA-512 hash function synchronous implementation.
+ * @param m - Variable number of Uint8Array arguments to concatenate and hash
+ * @returns The SHA-512 hash (512-bit/64 bytes) of the concatenated input bytes
  */
 ed25519.etc.sha512Sync = (...m) => sha512(ed25519.etc.concatBytes(...m))
 
@@ -47,8 +48,8 @@ const initializeCryptographyLibs = async () => {
 /**
  * Derives the public spending key from a given private key using the EdDSA algorithm.
  * @param privateKey - A 32-byte Uint8Array representing the private key.
- * @returns A tuple containing two bigints representing the public key coordinates.
- * @throws Error if the provided private key does not have a length of 32 bytes.
+ * @returns A tuple containing two Uint8Arrays representing the public key coordinates.
+ * @throws {Error} If the provided private key does not have a length of 32 bytes.
  */
 const getPublicSpendingKey = (privateKey: Uint8Array): [Uint8Array, Uint8Array] => {
   // convert this from
@@ -58,8 +59,8 @@ const getPublicSpendingKey = (privateKey: Uint8Array): [Uint8Array, Uint8Array] 
 
 /**
  * Derives the public viewing key from the given private viewing key.
- * @param privateViewingKey - A `Uint8Array` representing the private viewing key.
- * @returns A promise that resolves to a `Uint8Array` containing the derived public viewing key.
+ * @param privateViewingKey - A Uint8Array representing the private viewing key.
+ * @returns A Uint8Array containing the derived public viewing key.
  */
 const getPublicViewingKey = (
   privateViewingKey: Uint8Array
@@ -71,9 +72,10 @@ const getPublicViewingKey = (
  * Adjust bits to match the pattern xxxxx000...01xxxxxx for little endian and 01xxxxxx...xxxxx000 for big endian
  * This ensures that the bytes are a little endian representation of an integer of the form (2^254 + 8) * x where
  * 0 \< x \<= 2^251 - 1, which can be decoded as an X25519 integer.
- * @param bytes - bytes to adjust
- * @param endian - what endian to use
- * @returns adjusted bytes
+ * @param bytes - The Uint8Array bytes to adjust (must be 32 bytes)
+ * @param endian - The endian format to use ('be' for big endian, 'le' for little endian)
+ * @returns The adjusted bytes as a new Uint8Array
+ * @throws {Error} If bytes is not a Uint8Array of length 32
  */
 const adjustBytes25519 = (bytes: Uint8Array, endian: 'be' | 'le'): Uint8Array => {
   // Create new array to prevent side effects
@@ -124,7 +126,7 @@ const adjustBytes25519 = (bytes: Uint8Array, endian: 'be' | 'le'): Uint8Array =>
  * function returns a predefined constant `CURVE_L_BYTES`.
  * @param privateKey - A 32-byte Uint8Array representing the private key.
  * @returns A Promise that resolves to a Uint8Array containing the derived scalar.
- * @throws An error if the provided private key is not exactly 32 bytes.
+ * @throws {Error} If the provided private key is not exactly 32 bytes.
  */
 const getPrivateScalarFromPrivateKey = async (
   privateKey: Uint8Array
@@ -217,18 +219,18 @@ const scalarMultiplyJavascript = (
 /**
  * Generates a random scalar value using the Poseidon hash function.
  *
- * This function creates a random 32-byte value, converts it to a bigint,
- * and then hashes it using the Poseidon hash function to produce a scalar.
- * @returns A random scalar value derived from the Poseidon hash.
+ * This function creates a random 32-byte value and hashes it using the Poseidon hash function to produce a scalar.
+ * @returns A random scalar value (as Uint8Array) derived from the Poseidon hash.
  */
 const getRandomScalar = (): Uint8Array => {
   return poseidon([randomBytes(32)]) as Uint8Array
 }
 
 /**
- * Converts seed to curve scalar
- * @param seed - seed to convert
- * @returns scalar
+ * Converts seed to curve scalar.
+ * Hashes the seed to a 512-bit value and reduces it modulo the curve order.
+ * @param seed - The seed Uint8Array to convert
+ * @returns The scalar as a Uint8Array
  */
 const seedToScalar = (seed: Uint8Array): Uint8Array => {
   // Hash to 512 bit value as per FIPS-186
@@ -247,9 +249,9 @@ const seedToScalar = (seed: Uint8Array): Uint8Array => {
  * allowing the receiver to invert the blinding operation
  * Final random value is padded to 32 bytes
  * Get blinding scalar from random
- * @param sharedRandom - random value shared by both parties
- * @param senderRandom - random value only known to sender
- * @returns ephemeral keys
+ * @param sharedRandom - Random value shared by both parties (Uint8Array)
+ * @param senderRandom - Random value only known to sender (Uint8Array)
+ * @returns The blinding scalar as a bigint
  */
 const getBlindingScalar = (
   sharedRandom: Uint8Array,
@@ -265,11 +267,11 @@ const getBlindingScalar = (
 
 /**
  * Blinds sender and receiver public keys
- * @param senderViewingPublicKey - Sender's viewing public key
- * @param receiverViewingPublicKey - Receiver's viewing public key
- * @param sharedRandom - random value shared by both parties
- * @param senderRandom - random value only known to sender
- * @returns ephemeral keys
+ * @param senderViewingPublicKey - Sender's viewing public key (Uint8Array)
+ * @param receiverViewingPublicKey - Receiver's viewing public key (Uint8Array)
+ * @param sharedRandom - Random value shared by both parties (Uint8Array)
+ * @param senderRandom - Random value only known to sender (Uint8Array)
+ * @returns Object containing blindedSenderViewingKey and blindedReceiverViewingKey (both Uint8Array)
  */
 const getNoteBlindingKeys = (
   senderViewingPublicKey: Uint8Array,

--- a/src/seed/bip32.ts
+++ b/src/seed/bip32.ts
@@ -4,18 +4,21 @@ import type { KeyNode } from '../types.js'
 const CURVE_SEED = encodeBytes('babyjubjub seed') // same calculation as current engine
 
 /**
- * Tests derivation path to see if it's valid
- * @param path - bath to test
- * @returns valid
+ * Tests derivation path to see if it's valid.
+ * Valid paths must start with 'm' and contain only hardened derivation segments (e.g., "m/44'/0'/0'").
+ * @param path - The derivation path string to test
+ * @returns True if the path is valid, false otherwise
  */
 function isValidPath (path: string): boolean {
   return /^m(\/[0-9]+')+$/g.test(path)
 }
 
 /**
- * Converts path string into segments
- * @param path - path string to parse
- * @returns array of indexes
+ * Converts path string into segments.
+ * Parses a BIP32 derivation path and extracts the numeric indices.
+ * @param path - The derivation path string to parse (e.g., "m/44'/0'/0'")
+ * @returns Array of numeric indices extracted from the path
+ * @throws {Error} If the derivation path is invalid
  */
 function getPathSegments (path: string): number[] {
   // Throw if path is invalid
@@ -76,9 +79,10 @@ function childKeyDerivationHardened (
 }
 
 /**
- * Creates KeyNode from seed
- * @param seed - bip32 seed
- * @returns BjjNode - babyjubjub BIP32Node
+ * Creates KeyNode from seed.
+ * Generates the master key node using HMAC-SHA512 with the babyjubjub seed.
+ * @param seed - The BIP32 seed (Uint8Array)
+ * @returns KeyNode containing chainKey and chainCode
  */
 function getMasterKeyFromSeed (seed: Uint8Array): KeyNode {
   // HMAC with seed to get I

--- a/src/wallet-node/railgun.ts
+++ b/src/wallet-node/railgun.ts
@@ -55,9 +55,9 @@ export class RailgunWallet {
   private keystore: RailgunKeystore | undefined
 
   /**
-   * Constructs an instance of the Railgun class.
-   * @param mnemonic - The mnemonic phrase used to derive nodes.
-   * @param index - The index of the node to derive (default is 0).
+   * Constructs an instance of the RailgunWallet class.
+   * @param mnemonic - The mnemonic phrase used to derive wallet nodes.
+   * @param index - The derivation index for the wallet nodes (default is 0).
    */
   constructor (mnemonic: string, index: number = 0) {
     this.nodes = deriveNodes(mnemonic, index)

--- a/src/wallet-node/wallet-node.ts
+++ b/src/wallet-node/wallet-node.ts
@@ -7,6 +7,7 @@ import type { KeyNode, SpendingKeyPair, ViewingKeyPair } from '../types'
 
 const HARDENED_OFFSET = 0x80000000
 type WalletNodes = { spending: WalletNode; viewing: WalletNode }
+
 /**
  * The `WalletNode` class provides functionality for hierarchical deterministic wallet management,
  * including key derivation, cryptographic operations, and key pair generation. It encapsulates
@@ -52,7 +53,7 @@ class WalletNode {
 
   /**
    * Constructs a new instance of the WalletNode class.
-   * @param keyNode - An instance of the KeyNode class containing the chain key and chain code
+   * @param keyNode - A KeyNode object containing the chainKey and chainCode
    *                  used to initialize the WalletNode.
    */
   constructor (keyNode: KeyNode) {
@@ -71,9 +72,10 @@ class WalletNode {
   }
 
   /**
-   * Derives new BIP32Node along path
-   * @param path - path to derive along
-   * @returns - new BIP32 implementation Node
+   * Derives a new WalletNode along the specified BIP32 derivation path.
+   * @param path - The derivation path to follow (e.g., "m/44'/0'/0'")
+   * @returns A new WalletNode instance derived from the path
+   * @throws {Error} If the derivation path is invalid
    */
   derive (path: string): WalletNode {
     // Get path segments
@@ -92,8 +94,8 @@ class WalletNode {
   }
 
   /**
-   * Get spending key-pair
-   * @returns keypair
+   * Gets the spending key pair for this wallet node.
+   * @returns SpendingKeyPair object containing privateKey (Uint8Array) and pubkey (tuple of two Uint8Arrays)
    */
   getSpendingKeyPair (): SpendingKeyPair {
     const privateKey = this.chainKey
@@ -106,12 +108,10 @@ class WalletNode {
 
   /**
    * Generates the master public key using the provided spending public key and nullifying key.
-   * @param spendingPublicKey - A tuple containing two bigints representing the spending public key.
-   * @param nullifyingKey - A bigint representing the nullifying key.
+   * This function utilizes the Poseidon hash function to compute the master public key.
+   * @param spendingPublicKey - A tuple containing two Uint8Arrays representing the spending public key.
+   * @param nullifyingKey - A Uint8Array representing the nullifying key.
    * @returns A Uint8Array representing the computed master public key.
-   * This function utilizes the `poseidonFunc` to compute the master public key.
-   * Ensure that the input keys are properly converted to the expected format before calling this function.
-   * The conversion from `bigint` to `Uint8Array` is currently a TODO and should be implemented correctly.
    */
   static getMasterPublicKey (
     spendingPublicKey: [Uint8Array, Uint8Array],
@@ -128,8 +128,7 @@ class WalletNode {
    * The viewing key pair consists of a private key and a public viewing key.
    * The private key is derived from the node's chain key, and the public viewing key
    * is generated using the `getPublicViewingKey` function.
-   * @returns An object containing the private key and the public viewing key.
-   * @todo Refactor to use a separate node chain key for enhanced security.
+   * @returns ViewingKeyPair object containing privateKey and pubkey (both Uint8Arrays)
    */
   getViewingKeyPair (): ViewingKeyPair {
     // TODO: THIS should be a separate node chainkey
@@ -141,13 +140,8 @@ class WalletNode {
   /**
    * Generates the nullifying key for the wallet node.
    * This method calculates the nullifying key using the private key obtained
-   * from the viewing key pair. The calculation involves converting the private
-   * key into a bigint and applying the Poseidon hash function.
-   * @returns The calculated nullifying key.
-   * - The private key is currently recalculated every time this method is called.
-   *   Consider securely storing the private key to optimize performance.
-   * - The conversion and hashing process may need refinement to ensure proper
-   *   handling of data types (e.g., uint8 array vs bigint).
+   * from the viewing key pair and applies the Poseidon hash function.
+   * @returns The calculated nullifying key as a Uint8Array.
    */
   getNullifyingKey (): Uint8Array {
     // TODO: store these securely instead of calculating every time?


### PR DESCRIPTION
## Summary
- Add `uint8ArrayToHex` and `hexToUint8Array` utility functions to `hash.ts`
- Remove stray `console.log` in `bigIntToArray`
- Improve JSDoc accuracy across `keys.ts`, `bip32.ts`, and `wallet-node.ts`

## Changes
- `src/hash.ts` — new hex conversion utilities, console.log removal
- `src/keys.ts` — JSDoc improvements (no behavioral changes)
- `src/seed/bip32.ts` — JSDoc improvements (no behavioral changes)
- `src/wallet-node/railgun.ts` — JSDoc improvements (no behavioral changes)
- `src/wallet-node/wallet-node.ts` — JSDoc improvements (no behavioral changes)

## Stacked PR
This is **PR 2 of 4** in the note-types split:
1. #6 — Config/tooling
2. **This PR** — JSDoc improvements + hex conversion utilities
3. #8 — Note types, token utils, and note classes
4. #9 — Comprehensive test suite

**Base:** `pr/config-tooling` (PR #6)

## Test plan
- [ ] `npm run build` succeeds
- [ ] No behavioral changes except new hex utility exports