### PR TITLE
feat: implement note types, token utils, and note classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@msgpack/msgpack": "^3.1.3",
         "@noble/ed25519": "^2.3.0",
         "@noble/hashes": "^1.8.0",
         "@railgun-reloaded/0zk-addresses": "https://github.com/railgun-reloaded/0zk-addresses",
@@ -1009,6 +1010,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@noble/curves": {
@@ -6392,6 +6401,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="
     },
     "@noble/curves": {
       "version": "1.9.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "@msgpack/msgpack": "^3.1.3",
     "@noble/ed25519": "^2.3.0",
     "@noble/hashes": "^1.8.0",
     "@railgun-reloaded/0zk-addresses": "https://github.com/railgun-reloaded/0zk-addresses",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export * from './derive'
+export * from './notes'
+export * from './keys'

--- a/src/notes/decrypt-commitment.ts
+++ b/src/notes/decrypt-commitment.ts
@@ -1,0 +1,131 @@
+import { AES } from '@railgun-reloaded/cryptography'
+
+import { uint8ArrayToHex } from '../hash.js'
+import { getSharedSymmetricKey } from '../keys.js'
+
+import type { Ciphertext, TokenData } from './definitions.js'
+
+/**
+ * Result of successfully decrypting a commitment
+ */
+interface DecryptedCommitmentData {
+  random: string
+  npk: string
+  value: bigint
+  tokenData: TokenData
+}
+
+/**
+ * Attempts to decrypt a commitment ciphertext using a viewing key
+ * @param ciphertext - The encrypted ciphertext from the commitment
+ * @param blindedViewingKey - The blinded viewing key (sender or receiver)
+ * @param viewingPrivateKey - The wallet's viewing private key
+ * @returns The decrypted data or null if decryption fails
+ */
+async function decryptCommitment (
+  ciphertext: Ciphertext,
+  blindedViewingKey: Uint8Array,
+  viewingPrivateKey: Uint8Array
+): Promise<DecryptedCommitmentData | null> {
+  try {
+    // Compute shared symmetric key using ECDH
+    const sharedKey = await getSharedSymmetricKey(viewingPrivateKey, blindedViewingKey)
+    if (!sharedKey) {
+      return null
+    }
+
+    // Decrypt the ciphertext using AES-256-GCM
+    const decrypted = AES.decryptGCM(ciphertext, sharedKey)
+
+    // Parse decrypted data
+    // The decrypted data contains: [random (16 bytes), npk (32 bytes), value (32 bytes), tokenAddress (20 bytes), tokenType (1 byte), tokenSubID (32 bytes)]
+    const combinedData = decrypted[0]
+    if (!combinedData || combinedData.length < 16 + 32 + 32 + 20 + 1 + 32) {
+      return null
+    }
+
+    let offset = 0
+
+    // Extract random (16 bytes)
+    const randomBytes = combinedData.slice(offset, offset + 16)
+    const random = uint8ArrayToHex(randomBytes)
+    offset += 16
+
+    // Extract npk (32 bytes)
+    const npkBytes = combinedData.slice(offset, offset + 32)
+    const npk = uint8ArrayToHex(npkBytes)
+    offset += 32
+
+    // Extract value (32 bytes as big-endian bigint)
+    const valueBytes = combinedData.slice(offset, offset + 32)
+    let value = 0n
+    for (let i = 0; i < valueBytes.length; i++) {
+      value = (value << 8n) | BigInt(valueBytes[i] ?? 0)
+    }
+    offset += 32
+
+    // Extract tokenAddress (20 bytes)
+    const tokenAddressBytes = combinedData.slice(offset, offset + 20)
+    const tokenAddress = uint8ArrayToHex(tokenAddressBytes)
+    offset += 20
+
+    // Extract tokenType (1 byte)
+    const tokenType = combinedData[offset] ?? 0
+    offset += 1
+
+    // Extract tokenSubID (32 bytes)
+    const tokenSubIDBytes = combinedData.slice(offset, offset + 32)
+    const tokenSubID = uint8ArrayToHex(tokenSubIDBytes)
+
+    const tokenData: TokenData = {
+      tokenType,
+      tokenAddress,
+      tokenSubID
+    }
+
+    return { random, npk, value, tokenData }
+  } catch (error) {
+    // Decryption failed - commitment not for this wallet
+    return null
+  }
+}
+
+/**
+ * Attempts to decrypt a commitment as either receiver or sender
+ * @param ciphertext - The encrypted ciphertext from the commitment
+ * @param blindedReceiverViewingKey - The blinded receiver viewing key
+ * @param blindedSenderViewingKey - The blinded sender viewing key
+ * @param viewingPrivateKey - The wallet's viewing private key
+ * @returns Object with decrypted data and role (receiver/sender), or null if decryption fails
+ */
+async function decryptCommitmentAsReceiverOrSender (
+  ciphertext: Ciphertext,
+  blindedReceiverViewingKey: Uint8Array,
+  blindedSenderViewingKey: Uint8Array,
+  viewingPrivateKey: Uint8Array
+): Promise<{ data: DecryptedCommitmentData, isReceiver: boolean } | null> {
+  // Try as receiver first
+  const receiverData = await decryptCommitment(
+    ciphertext,
+    blindedReceiverViewingKey,
+    viewingPrivateKey
+  )
+  if (receiverData) {
+    return { data: receiverData, isReceiver: true }
+  }
+
+  // Try as sender
+  const senderData = await decryptCommitment(
+    ciphertext,
+    blindedSenderViewingKey,
+    viewingPrivateKey
+  )
+  if (senderData) {
+    return { data: senderData, isReceiver: false }
+  }
+
+  return null
+}
+
+export type { DecryptedCommitmentData }
+export { decryptCommitment, decryptCommitmentAsReceiverOrSender }

--- a/src/notes/definitions.ts
+++ b/src/notes/definitions.ts
@@ -1,0 +1,280 @@
+/**
+ * SNARK scalar field prime used in RAILGUN's zero-knowledge proofs.
+ * This is the maximum value for field elements in the BN254 curve.
+ */
+const SNARK_PRIME = 21888242871839275222246405745257275088548364400416034343698204186575808495617n as const
+
+/**
+ * Standard value for ERC721 notes - always 1 since NFTs are non-fungible.
+ */
+const ERC721_NOTE_VALUE = 1n as const
+
+/**
+ * Scanner commitment types - used for type safety when converting scanner data.
+ * These types match the scanner's output format.
+ */
+type GeneratedCommitment = {
+  hash: Uint8Array;
+  treeNumber: number;
+  treePosition: number;
+  preimage: {
+    npk: Uint8Array;
+    value: bigint;
+    token: {
+      tokenAddress: Uint8Array;
+      tokenType: string; // Scanner uses string, needs conversion to TokenType enum
+      tokenSubID: Uint8Array;
+    };
+  };
+  encryptedRandom: Uint8Array[];
+}
+
+type ShieldCommitment = {
+  hash: Uint8Array;
+  treeNumber: number;
+  treePosition: number;
+  preimage: {
+    npk: Uint8Array;
+    value: bigint;
+    token: {
+      tokenAddress: Uint8Array;
+      tokenType: string; // Scanner uses string, needs conversion to TokenType enum
+      tokenSubID: Uint8Array;
+    };
+  };
+  encryptedBundle: Uint8Array[];
+  shieldKey: Uint8Array;
+  fee?: bigint;
+}
+
+/**
+ * Unshield data type - used when converting unshield events to notes.
+ */
+type UnshieldData = {
+  to: Uint8Array;
+  token: {
+    tokenAddress: Uint8Array;
+    tokenType: string; // Uses string, needs conversion to TokenType enum
+    tokenSubID: Uint8Array;
+  };
+  amount: bigint;
+  fee: bigint;
+}
+
+/**
+ * Ciphertext type - used in encrypted commitments.
+ */
+type Ciphertext = {
+  iv: Uint8Array;
+  tag: Uint8Array;
+  data: Uint8Array[];
+}
+
+/**
+ * Transact commitment type - used when converting transact events to notes.
+ */
+type TransactCommitment = {
+  hash: Uint8Array;
+  ciphertext: Ciphertext;
+  blindedSenderViewingKey: Uint8Array;
+  blindedReceiverViewingKey: Uint8Array;
+  annotationData: Uint8Array;
+  memo: Uint8Array[];
+  treeNumber: number;
+  treePosition: number;
+}
+
+/**
+ * Encrypted commitment type - used when converting encrypted commitment events to notes.
+ */
+type EncryptedCommitment = {
+  hash: Uint8Array;
+  ciphertext: Ciphertext;
+  memo: Uint8Array[];
+  ephemeralKeys: Uint8Array[];
+  treeNumber: number;
+  treePosition: number;
+}
+
+/**
+ * TokenType
+ * Enumeration of supported token types in the Railgun system.
+ */
+enum TokenType {
+  ERC20 = 0,
+  ERC721 = 1,
+  ERC1155 = 2,
+}
+
+/**
+ * OutputType
+ * Enumeration of output types in transactions.
+ */
+enum OutputType {
+  Transfer = 0,
+  BroadcasterFee = 1,
+  Change = 2,
+}
+
+/**
+ *
+ * Represents data for a token, including its type, address, and sub-ID.
+ */
+type TokenData = {
+  tokenType: TokenType;
+  tokenAddress: string;
+  tokenSubID: string;
+}
+
+/**
+ * ChainType
+ * Enumeration of supported blockchain chain types.
+ */
+enum ChainType {
+  EVM = 0,
+}
+
+/**
+ *
+ * Represents a blockchain chain with its type and ID.
+ */
+type Chain = {
+  type: ChainType;
+  id: number;
+}
+
+/**
+ *
+ * Contains address-related data including public keys and optional chain/version info.
+ */
+type AddressData = {
+  masterPublicKey: bigint;
+  viewingPublicKey: Uint8Array;
+  chain?: Chain;
+  version?: number;
+}
+
+/**
+ *
+ * Represents the ciphertext data for a note, including IV, tag, and encrypted data.
+ */
+type NoteCiphertext = {
+  iv: string;
+  tag: string;
+  data: string[];
+}
+
+/**
+ * Legacy ciphertext format using AES-GCM encryption.
+ * Used for backward compatibility with older note formats.
+ */
+type LegacyCiphertext = {
+  iv: string;
+  tag: string;
+  data: string[];
+}
+
+/**
+ * Encrypted data tuple: [ivTag, data]
+ * Used in legacy note serialization.
+ */
+type EncryptedData = [string, string]
+
+/**
+ * Note annotation data containing output type, sender random, and wallet source.
+ */
+type NoteAnnotationData = {
+  outputType: OutputType;
+  senderRandom: string;
+  walletSource: string | undefined;
+}
+
+/**
+ * Base interface for all note types, containing common properties.
+ * notePublicKey - Also known as npk
+ * random - 16 byte random
+ * value - The value of the note
+ * tokenData - Token data
+ */
+interface NoteBase {
+  notePublicKey: string;
+  random: string;
+  value: bigint;
+  tokenData: TokenData;
+}
+
+/**
+ * Interface for shield notes, extending NoteBase with additional properties for shielding.
+ */
+interface ShieldNote extends NoteBase {
+  masterPublicKey: bigint;
+  tokenHash: string;
+}
+
+/**
+ * Interface for transaction notes, extending NoteBase with sender/receiver data and transaction details.
+ * receiverAddressData - address data of recipient
+ * senderAddressData - address data of sender
+ * tokenHash - 32 byte hash of token data
+ * hash - Note hash
+ * shieldFee - Only used during serialization/storage of ShieldCommitments.
+ */
+interface TransactNote extends NoteBase {
+  receiverAddressData: AddressData;
+  senderAddressData: AddressData | undefined;
+  tokenHash: string;
+  hash: bigint;
+  outputType: OutputType | undefined;
+  walletSource: string | undefined;
+  senderRandom: string | undefined;
+  memoText: string | undefined;
+  shieldFee: string | undefined;
+  blockNumber: number | undefined;
+}
+
+/**
+ * Interface for unshield notes, extending NoteBase with unshielding-specific properties.
+ */
+interface UnshieldNote extends NoteBase {
+  toAddress: string;
+  hash: bigint;
+  allowOverride: boolean;
+}
+
+/**
+ * Legacy serialized transact note format.
+ * Used for backward compatibility with older database entries.
+ * DO NOT MODIFY - This format is stored in databases.
+ */
+interface LegacyTransactNoteSerialized {
+  npk: string;
+  value: string;
+  tokenHash: string;
+  encryptedRandom: EncryptedData;
+  memoField: string[];
+  recipientAddress: string;
+  memoText: string | undefined;
+  blockNumber: number | undefined;
+}
+
+/**
+ * Modern serialized transact note format.
+ * DO NOT MODIFY - This format is stored in databases.
+ */
+interface TransactNoteSerialized {
+  npk: string;
+  value: string;
+  tokenHash: string;
+  random: string;
+  recipientAddress: string;
+  outputType: OutputType | undefined;
+  senderRandom: string | undefined;
+  walletSource: string | undefined;
+  senderAddress: string | undefined;
+  memoText: string | undefined;
+  shieldFee: string | undefined;
+  blockNumber: number | undefined;
+}
+
+export type { TokenData, Chain, AddressData, NoteCiphertext, LegacyCiphertext, EncryptedData, NoteAnnotationData, NoteBase, ShieldNote, TransactNote, LegacyTransactNoteSerialized, TransactNoteSerialized, UnshieldNote, GeneratedCommitment, ShieldCommitment, UnshieldData, Ciphertext, TransactCommitment, EncryptedCommitment }
+export { TokenType, OutputType, ChainType, SNARK_PRIME, ERC721_NOTE_VALUE }

--- a/src/notes/index.ts
+++ b/src/notes/index.ts
@@ -1,0 +1,9 @@
+export * from './decrypt-commitment'
+export * from './definitions'
+export * from './token-utils'
+export * from './note-utils'
+
+export { Note } from './note'
+export { ShieldNote } from './shield-note'
+export { UnshieldNote } from './unshield-note'
+export { TransactNote, ciphertextToEncryptedRandomData, encryptedDataToCiphertext, isLegacyTransactNote } from './transact-note'

--- a/src/notes/note-utils.ts
+++ b/src/notes/note-utils.ts
@@ -1,0 +1,45 @@
+import { poseidon } from '@railgun-reloaded/cryptography'
+
+import { bigintToUint8Array, hexToUint8Array, uint8ArrayToBigInt } from '../hash.js'
+
+import type { TokenData } from './definitions.js'
+import { computeTokenHash } from './token-utils.js'
+
+/**
+ * Validates that random value is the correct length (16 bytes).
+ * @param random - The random value to validate (hex string)
+ * @throws {Error} If validation fails
+ */
+function assertValidNoteRandom (random: string): void {
+  const cleanRandom = random.startsWith('0x') ? random.slice(2) : random
+
+  if (cleanRandom.length !== 32) {
+    throw new Error(
+      `Random must be length 32 hex chars (16 bytes). Got ${random}.`
+    )
+  }
+}
+
+/**
+ * Computes the note hash from address, token data, and value.
+ * NOTE: Requires cryptography libraries to be initialized first via initializeCryptographyLibs()
+ * @param address - The note public key (npk) as a hex string
+ * @param tokenData - The token data containing type, address, and subID
+ * @param value - The note value as a bigint
+ * @returns The note hash as a bigint
+ * @throws {Error} If cryptography libraries are not initialized
+ */
+function getNoteHash (address: string, tokenData: TokenData, value: bigint): bigint {
+  const tokenHash = computeTokenHash(tokenData)
+  const addressBytes = hexToUint8Array(address)
+  const tokenHashBytes = hexToUint8Array(tokenHash)
+  const valueBytes = bigintToUint8Array(value, 16) // 128-bit value
+
+  const hash = poseidon([addressBytes, tokenHashBytes, valueBytes])
+  return uint8ArrayToBigInt(hash)
+}
+
+export {
+  assertValidNoteRandom,
+  getNoteHash
+}

--- a/src/notes/note.ts
+++ b/src/notes/note.ts
@@ -1,0 +1,70 @@
+import type { TokenData } from './definitions.js'
+import { computeTokenHash } from './token-utils.js'
+
+/**
+ * Abstract base class for all note types.
+ * Provides common properties and serialization interface.
+ */
+abstract class Note {
+  /**
+   * The note public key (npk) as a hex string
+   */
+  notePublicKey: string
+
+  /**
+   * The note value as a bigint
+   */
+  value: bigint
+
+  /**
+   * The token data containing address, type, and subID
+   */
+  tokenData: TokenData
+
+  /**
+   * The token hash as a hex string
+   */
+  tokenHash: string
+
+  /**
+   * Random value (16 bytes hex string)
+   */
+  random: string
+
+  /**
+   * Constructs a new Note instance.
+   * @param notePublicKey - The note public key
+   * @param value - The note value
+   * @param tokenData - The token data
+   * @param random - Random value (16 bytes hex string)
+   */
+  constructor (
+    notePublicKey: string,
+    value: bigint,
+    tokenData: TokenData,
+    random: string
+  ) {
+    this.notePublicKey = notePublicKey
+    this.value = value
+    this.tokenData = tokenData
+    this.tokenHash = computeTokenHash(tokenData)
+    this.random = random
+  }
+
+  /**
+   * Serializes the note to a Uint8Array.
+   * Must be implemented by subclasses.
+   * @returns The serialized note
+   */
+  abstract serialize (): Uint8Array
+
+  /**
+   * Gets the computed token hash for this note.
+   * @returns The token hash
+   */
+  getTokenHash (): string {
+    return this.tokenHash
+  }
+}
+
+export { Note }

--- a/src/notes/shield-note.ts
+++ b/src/notes/shield-note.ts
@@ -1,0 +1,139 @@
+import { decode, encode } from '@msgpack/msgpack'
+
+import { uint8ArrayToBigInt, uint8ArrayToHex } from '../hash.js'
+
+import type { GeneratedCommitment, ShieldCommitment, TokenData, TokenType } from './definitions.js'
+import { Note } from './note.js'
+import { deserializeTokenData } from './token-utils.js'
+
+/**
+ * Represents a Shield note with master public key.
+ */
+class ShieldNote extends Note {
+  /**
+   * The master public key as a bigint
+   */
+  masterPublicKey: bigint
+
+  /**
+   * Constructs a new ShieldNote instance.
+   * @param notePublicKey - The note public key
+   * @param value - The note value
+   * @param tokenData - The token data
+   * @param random - Random value (16 bytes hex string)
+   * @param masterPublicKey - The master public key
+   */
+  constructor (
+    notePublicKey: string,
+    value: bigint,
+    tokenData: TokenData,
+    random: string,
+    masterPublicKey: bigint
+  ) {
+    super(notePublicKey, value, tokenData, random)
+    this.masterPublicKey = masterPublicKey
+  }
+
+  /**
+   * Serializes the shield note to a Uint8Array using msgpack encoding.
+   * @returns The serialized shield note
+   */
+  serialize (): Uint8Array {
+    return encode({
+      random: this.random,
+      tokenHash: this.tokenHash,
+      notePublicKey: this.notePublicKey,
+      value: this.value.toString(),
+      masterPublicKey: this.masterPublicKey.toString(),
+      token: {
+        tokenAddress: this.tokenData.tokenAddress,
+        tokenType: this.tokenData.tokenType,
+        tokenSubID: this.tokenData.tokenSubID,
+      },
+    })
+  }
+
+  /**
+   * Deserializes a shield note from a Uint8Array.
+   * @param bytes - The serialized shield note data
+   * @returns A new ShieldNote instance
+   */
+  static deserialize (bytes: Uint8Array): ShieldNote {
+    const { notePublicKey, masterPublicKey, token, value, random } = decode(bytes) as any
+
+    return new ShieldNote(
+      notePublicKey,
+      BigInt(value),
+      deserializeTokenData(token),
+      random,
+      BigInt(masterPublicKey)
+    )
+  }
+
+  /**
+   * Creates a ShieldNote from commitment data.
+   * Handles both GeneratedCommitment and ShieldCommitment types.
+   * NOTE: Requires cryptography libraries to be initialized first via initializeCryptographyLibs()
+   * @param commitment - The commitment object
+   * @param masterPublicKey - Optional master public key as bigint (required for GeneratedCommitment)
+   * @returns A new ShieldNote instance
+   * @throws {Error} If required fields are missing or poseidon is not initialized
+   */
+  static fromCommitment (
+    commitment: GeneratedCommitment | ShieldCommitment,
+    masterPublicKey?: bigint
+  ): ShieldNote {
+    // Extract random from encryptedRandom (GeneratedCommitment) or encryptedBundle (ShieldCommitment)
+    const randomBytes = 'encryptedRandom' in commitment
+      ? commitment.encryptedRandom?.[0]
+      : commitment.encryptedBundle?.[0]
+
+    if (!randomBytes) {
+      throw new Error('Missing random data in commitment')
+    }
+
+    // Extract masterPublicKey from shieldKey (ShieldCommitment) or use provided parameter
+    let mpk: bigint
+    if ('shieldKey' in commitment && commitment.shieldKey) {
+      mpk = uint8ArrayToBigInt(commitment.shieldKey)
+    } else if (masterPublicKey !== undefined) {
+      mpk = masterPublicKey
+    } else {
+      throw new Error('Missing masterPublicKey - required for GeneratedCommitment')
+    }
+
+    const { npk, value, token: { tokenAddress, tokenSubID, tokenType } } = commitment.preimage
+
+    // Convert tokenType string to TokenType enum number
+    let tokenTypeNum: TokenType
+    switch (tokenType.toUpperCase()) {
+      case 'ERC20':
+        tokenTypeNum = 0 // TokenType.ERC20
+        break
+      case 'ERC721':
+        tokenTypeNum = 1 // TokenType.ERC721
+        break
+      case 'ERC1155':
+        tokenTypeNum = 2 // TokenType.ERC1155
+        break
+      default:
+        throw new Error(`Invalid tokenType: ${tokenType}`)
+    }
+
+    const tokenData: TokenData = {
+      tokenType: tokenTypeNum,
+      tokenAddress: uint8ArrayToHex(tokenAddress),
+      tokenSubID: uint8ArrayToHex(tokenSubID),
+    }
+
+    return new ShieldNote(
+      uint8ArrayToHex(npk),
+      value,
+      tokenData,
+      uint8ArrayToHex(randomBytes),
+      mpk
+    )
+  }
+}
+
+export { ShieldNote }

--- a/src/notes/token-utils.ts
+++ b/src/notes/token-utils.ts
@@ -1,0 +1,196 @@
+import { keccak_256 as keccak256 } from '@noble/hashes/sha3'
+
+import { bigintToUint8Array, hexToUint8Array, uint8ArrayToBigInt, uint8ArrayToHex } from '../hash.js'
+
+import type { TokenData } from './definitions.js'
+import { SNARK_PRIME } from './definitions.js'
+
+/**
+ * Computes the token hash for ERC20 tokens.
+ * ERC20 token hash is simply the token address padded to 32 bytes.
+ * @param tokenAddress - The ERC20 token address (hex string)
+ * @returns The token hash as a hex string (32 bytes)
+ */
+function computeTokenHashERC20 (tokenAddress: string): string {
+  const cleanAddress = tokenAddress.startsWith('0x') ? tokenAddress.slice(2) : tokenAddress
+  // Pad to 32 bytes (64 hex chars)
+  const padded = cleanAddress.padStart(64, '0')
+  return '0x' + padded
+}
+
+/**
+ * Computes the token hash for NFT tokens (ERC721/ERC1155).
+ * NFT token hash uses keccak256 of (tokenType + tokenAddress + tokenSubID) mod SNARK_PRIME.
+ * @param tokenData - The NFT token data
+ * @returns The token hash as a hex string (32 bytes)
+ */
+function computeTokenHashNFT (tokenData: TokenData): string {
+  // Prepare 32-byte components
+  const tokenTypeBytes = bigintToUint8Array(BigInt(tokenData.tokenType), 32)
+  const tokenAddressBytes = hexToUint8Array(tokenData.tokenAddress)
+
+  // Pad address to 32 bytes if needed
+  const paddedAddress = new Uint8Array(32)
+  paddedAddress.set(tokenAddressBytes, 32 - tokenAddressBytes.length)
+
+  const tokenSubIDBytes = hexToUint8Array(tokenData.tokenSubID)
+
+  // Combine: tokenType (32) + tokenAddress (32) + tokenSubID (32) = 96 bytes
+  const combined = new Uint8Array(96)
+  combined.set(tokenTypeBytes, 0)
+  combined.set(paddedAddress, 32)
+  combined.set(tokenSubIDBytes, 64)
+
+  // Hash with keccak256
+  const hashed = keccak256(combined)
+  const hashedBigInt = uint8ArrayToBigInt(hashed)
+
+  // Modulo SNARK_PRIME
+  const modulo = hashedBigInt % SNARK_PRIME
+
+  return uint8ArrayToHex(bigintToUint8Array(modulo, 32), true)
+}
+
+/**
+ * Computes the token hash from token data.
+ * Uses different algorithms based on token type:
+ * - ERC20: Direct address padding
+ * - ERC721/ERC1155: keccak256 hash modulo SNARK_PRIME
+ * @param tokenData - The token data to hash
+ * @returns The token hash as a hex string
+ */
+function computeTokenHash (tokenData: TokenData): string {
+  switch (tokenData.tokenType) {
+    case 0: // TokenType.ERC20
+      return computeTokenHashERC20(tokenData.tokenAddress)
+    case 1: // TokenType.ERC721
+    case 2: // TokenType.ERC1155
+      return computeTokenHashNFT(tokenData)
+    default:
+      throw new Error(`Unrecognized token type: ${tokenData.tokenType}`)
+  }
+}
+
+/**
+ * Gets a human-readable representation of a token address.
+ * @param tokenData - The token data
+ * @returns A formatted string representation
+ */
+function getReadableTokenAddress (tokenData: TokenData): string {
+  switch (tokenData.tokenType) {
+    case 0: { // TokenType.ERC20
+      const cleanAddress = tokenData.tokenAddress.startsWith('0x')
+        ? tokenData.tokenAddress.slice(2)
+        : tokenData.tokenAddress
+      // Trim to 20 bytes (40 hex chars)
+      const trimmed = cleanAddress.slice(-40)
+      return '0x' + trimmed
+    }
+    case 1: // TokenType.ERC721
+    case 2: // TokenType.ERC1155
+      return `${tokenData.tokenAddress} (${tokenData.tokenSubID})`
+    default:
+      throw new Error(`Unrecognized token type: ${tokenData.tokenType}`)
+  }
+}
+
+/**
+ * Serializes token data to a plain object.
+ * @param token - The token data to serialize
+ * @returns The serialized token data object
+ */
+function serializeTokenData (token: TokenData): object {
+  return {
+    tokenAddress: token.tokenAddress,  // string
+    tokenType: token.tokenType,        // number
+    tokenSubID: token.tokenSubID,      // string
+  }
+}
+
+/**
+ * Deserializes token data from a plain object.
+ * @param data - The object containing serialized token data
+ * @returns The deserialized TokenData object
+ */
+function deserializeTokenData (data: any): TokenData {
+  return {
+    tokenAddress: data.tokenAddress,
+    tokenType: data.tokenType,
+    tokenSubID: data.tokenSubID,
+  }
+}
+
+/**
+ * Validates that a note's token data and value are valid.
+ * @param tokenData - The token data to validate
+ * @param value - The note value to validate
+ * @throws {Error} If validation fails
+ */
+function assertValidNoteToken (tokenData: TokenData, value: bigint): void {
+  const addressHex = tokenData.tokenAddress.startsWith('0x')
+    ? tokenData.tokenAddress.slice(2)
+    : tokenData.tokenAddress
+  const addressLength = addressHex.length
+
+  switch (tokenData.tokenType) {
+    case 0: {
+      // TokenType.ERC20
+      if (addressLength !== 40 && addressLength !== 64) {
+        throw new Error(
+          `ERC20 address must be length 40 (20 bytes) or 64 (32 bytes). Got ${tokenData.tokenAddress}.`
+        )
+      }
+
+      const subID = BigInt(tokenData.tokenSubID)
+      if (subID !== 0n) {
+        throw new Error('ERC20 note cannot have tokenSubID parameter.')
+      }
+
+      return
+    }
+    case 1: {
+      // TokenType.ERC721
+      if (addressLength !== 40) {
+        throw new Error(
+          `ERC721 address must be length 40 (20 bytes). Got ${tokenData.tokenAddress}.`
+        )
+      }
+
+      if (!tokenData.tokenSubID || tokenData.tokenSubID === '0x' || tokenData.tokenSubID === '0x0') {
+        throw new Error('ERC721 note must have tokenSubID parameter.')
+      }
+
+      if (value !== BigInt(1)) {
+        throw new Error('ERC721 note must have value of 1.')
+      }
+
+      return
+    }
+    case 2: {
+      // TokenType.ERC1155
+      if (addressLength !== 40) {
+        throw new Error(
+          `ERC1155 address must be length 40 (20 bytes). Got ${tokenData.tokenAddress}.`
+        )
+      }
+
+      if (!tokenData.tokenSubID || tokenData.tokenSubID === '0x' || tokenData.tokenSubID === '0x0') {
+        throw new Error('ERC1155 note must have tokenSubID parameter.')
+      }
+
+      return
+    }
+    default:
+      throw new Error(`Unrecognized token type: ${tokenData.tokenType}`)
+  }
+}
+
+export {
+  computeTokenHashERC20,
+  computeTokenHashNFT,
+  computeTokenHash,
+  getReadableTokenAddress,
+  serializeTokenData,
+  deserializeTokenData,
+  assertValidNoteToken
+}

--- a/src/notes/transact-note.ts
+++ b/src/notes/transact-note.ts
@@ -1,0 +1,356 @@
+import { decode, encode } from '@msgpack/msgpack'
+import { AES } from '@railgun-reloaded/cryptography'
+
+import { hexToUint8Array, uint8ArrayToHex } from '../hash.js'
+import { getSharedSymmetricKey } from '../keys.js'
+
+import type { AddressData, Ciphertext, EncryptedCommitment, EncryptedData, LegacyCiphertext, TokenData, TransactCommitment } from './definitions.js'
+import { getNoteHash } from './note-utils.js'
+import { Note } from './note.js'
+import { deserializeTokenData } from './token-utils.js'
+
+/**
+ * Represents a Transact note with additional metadata for transactions.
+ */
+class TransactNote extends Note {
+  /**
+   * The note hash as a bigint
+   */
+  hash: bigint
+
+  /**
+   * Receiver address data
+   */
+  receiverAddressData: AddressData
+
+  /**
+   * Optional sender address data
+   */
+  senderAddressData: AddressData | undefined
+
+  /**
+   * Optional output type
+   */
+  outputType: number | undefined
+
+  /**
+   * Optional wallet source
+   */
+  walletSource: string | undefined
+
+  /**
+   * Optional sender random value
+   */
+  senderRandom: string | undefined
+
+  /**
+   * Optional memo text
+   */
+  memoText: string | undefined
+
+  /**
+   * Optional shield fee
+   */
+  shieldFee: string | undefined
+
+  /**
+   * Optional block number
+   */
+  blockNumber: number | undefined
+
+  /**
+   * Constructs a new TransactNote instance.
+   * @param notePublicKey - The note public key
+   * @param value - The note value
+   * @param tokenData - The token data
+   * @param random - Random value (16 bytes hex string)
+   * @param hash - The note hash
+   * @param receiverAddressData - Receiver address data
+   * @param senderAddressData - Optional sender address data
+   * @param outputType - Optional output type
+   * @param walletSource - Optional wallet source
+   * @param senderRandom - Optional sender random value
+   * @param memoText - Optional memo text
+   * @param shieldFee - Optional shield fee
+   * @param blockNumber - Optional block number
+   */
+  constructor (
+    notePublicKey: string,
+    value: bigint,
+    tokenData: TokenData,
+    random: string,
+    hash: bigint,
+    receiverAddressData: AddressData,
+    senderAddressData?: AddressData,
+    outputType?: number,
+    walletSource?: string,
+    senderRandom?: string,
+    memoText?: string,
+    shieldFee?: string,
+    blockNumber?: number
+  ) {
+    super(notePublicKey, value, tokenData, random)
+    this.hash = hash
+    this.receiverAddressData = receiverAddressData
+    this.senderAddressData = senderAddressData
+    this.outputType = outputType
+    this.walletSource = walletSource
+    this.senderRandom = senderRandom
+    this.memoText = memoText
+    this.shieldFee = shieldFee
+    this.blockNumber = blockNumber
+  }
+
+  /**
+   * Serializes the transact note to a Uint8Array using msgpack encoding.
+   * @returns The serialized transact note
+   */
+  serialize (): Uint8Array {
+    return encode({
+      random: this.random,
+      tokenHash: this.tokenHash,
+      notePublicKey: this.notePublicKey,
+      value: this.value.toString(),
+      hash: this.hash.toString(),
+      outputType: this.outputType,
+      walletSource: this.walletSource,
+      senderRandom: this.senderRandom,
+      memoText: this.memoText,
+      shieldFee: this.shieldFee,
+      blockNumber: this.blockNumber,
+      token: {
+        tokenAddress: this.tokenData.tokenAddress,
+        tokenType: this.tokenData.tokenType,
+        tokenSubID: this.tokenData.tokenSubID,
+      },
+      receiverAddressData: this.receiverAddressData
+        ? {
+            masterPublicKey: this.receiverAddressData.masterPublicKey.toString(),
+            viewingPublicKey: uint8ArrayToHex(this.receiverAddressData.viewingPublicKey),
+          }
+        : undefined,
+      senderAddressData: this.senderAddressData
+        ? {
+            masterPublicKey: this.senderAddressData.masterPublicKey.toString(),
+            viewingPublicKey: uint8ArrayToHex(this.senderAddressData.viewingPublicKey),
+          }
+        : undefined,
+    })
+  }
+
+  /**
+   * Deserializes a transact note from a Uint8Array.
+   * @param bytes - The serialized transact note data
+   * @returns A new TransactNote instance
+   */
+  static deserialize (bytes: Uint8Array): TransactNote {
+    const data = decode(bytes) as any
+
+    const receiverAddressData: AddressData = data.receiverAddressData
+      ? {
+          masterPublicKey: BigInt(data.receiverAddressData.masterPublicKey),
+          viewingPublicKey: hexToUint8Array(data.receiverAddressData.viewingPublicKey),
+        }
+      : { masterPublicKey: 0n, viewingPublicKey: new Uint8Array(32) }
+
+    return new TransactNote(
+      data.notePublicKey,
+      BigInt(data.value),
+      deserializeTokenData(data.token),
+      data.random,
+      BigInt(data.hash),
+      receiverAddressData,
+      data.senderAddressData
+        ? {
+            masterPublicKey: BigInt(data.senderAddressData.masterPublicKey),
+            viewingPublicKey: hexToUint8Array(data.senderAddressData.viewingPublicKey),
+          }
+        : undefined,
+      data.outputType,
+      data.walletSource,
+      data.senderRandom,
+      data.memoText,
+      data.shieldFee,
+      data.blockNumber
+    )
+  }
+
+  /**
+   * Creates a TransactNote from commitment data.
+   * NOTE: This converts only the commitment data. Full decryption requires viewing keys.
+   * NOTE: Requires cryptography libraries to be initialized first via initializeCryptographyLibs()
+   * @param _commitment - The TransactCommitment or EncryptedCommitment (reserved for future use)
+   * @param random - Random value (16 bytes hex string) - from decrypted ciphertext
+   * @param npk - Note public key (hex string) - from decrypted ciphertext
+   * @param value - Note value (bigint) - from decrypted ciphertext
+   * @param tokenData - Token data - from decrypted ciphertext
+   * @param receiverAddressData - Receiver address data
+   * @param senderAddressData - Optional sender address data
+   * @returns A new TransactNote instance
+   */
+  static fromCommitment (
+    _commitment: TransactCommitment | EncryptedCommitment,
+    random: string,
+    npk: string,
+    value: bigint,
+    tokenData: TokenData,
+    receiverAddressData: AddressData,
+    senderAddressData?: AddressData
+  ): TransactNote {
+    const hash = getNoteHash(npk, tokenData, value)
+
+    return new TransactNote(
+      npk,
+      value,
+      tokenData,
+      random,
+      hash,
+      receiverAddressData,
+      senderAddressData
+    )
+  }
+
+  /**
+   * Serializes a transact note in legacy format (for backward compatibility).
+   * Legacy format uses encrypted random field instead of plain random.
+   * @param viewingPrivateKey - Viewing private key for encryption (32 bytes)
+   * @param receiverViewingPublicKey - Receiver's viewing public key for encryption (32 bytes)
+   * @returns The serialized legacy transact note
+   */
+  async serializeLegacy (viewingPrivateKey: Uint8Array, receiverViewingPublicKey: Uint8Array): Promise<Uint8Array> {
+    // Get shared symmetric key for encryption
+    const sharedKey = await getSharedSymmetricKey(viewingPrivateKey, receiverViewingPublicKey)
+    if (!sharedKey) {
+      throw new Error('Failed to generate shared symmetric key')
+    }
+
+    // Encrypt the random value using AES-GCM
+    const randomBytes = hexToUint8Array(this.random)
+    const ciphertext = AES.encryptGCM([randomBytes], sharedKey)
+
+    // Convert ciphertext to legacy format [ivTag, data]
+    const ivTag = uint8ArrayToHex(ciphertext.iv, false) + uint8ArrayToHex(ciphertext.tag, false)
+    const encryptedData = ciphertext.data[0] ? uint8ArrayToHex(ciphertext.data[0], false) : ''
+    const encryptedRandom: EncryptedData = [ivTag, encryptedData]
+
+    return encode({
+      npk: this.notePublicKey,
+      value: this.value.toString(),
+      tokenHash: this.tokenHash,
+      encryptedRandom,
+      memoField: [],
+      recipientAddress: this.receiverAddressData
+        ? uint8ArrayToHex(this.receiverAddressData.viewingPublicKey)
+        : '0x' + '00'.repeat(32),
+      memoText: this.memoText,
+      blockNumber: this.blockNumber,
+    })
+  }
+
+  /**
+   * Deserializes a legacy transact note.
+   * @param bytes - The serialized legacy note data
+   * @param viewingPrivateKey - Viewing private key for decryption (32 bytes)
+   * @param senderViewingPublicKey - Sender's viewing public key for decryption (32 bytes)
+   * @returns A new TransactNote instance
+   */
+  static async deserializeLegacy (
+    bytes: Uint8Array,
+    viewingPrivateKey: Uint8Array,
+    senderViewingPublicKey: Uint8Array
+  ): Promise<TransactNote> {
+    const data = decode(bytes) as any
+
+    // Get shared symmetric key for decryption
+    const sharedKey = await getSharedSymmetricKey(viewingPrivateKey, senderViewingPublicKey)
+
+    if (!sharedKey) {
+      throw new Error('Failed to generate shared symmetric key')
+    }
+
+    // Parse encrypted random from legacy format
+    const encryptedData = data.encryptedRandom as EncryptedData
+    const [ivTag, encryptedRandomData] = encryptedData
+
+    // Extract IV and tag from ivTag
+    const iv = hexToUint8Array('0x' + ivTag.slice(0, 32))
+    const tag = hexToUint8Array('0x' + ivTag.slice(32))
+    const encData = hexToUint8Array('0x' + encryptedRandomData)
+
+    // Decrypt using AES-GCM
+    const ciphertext: Ciphertext = { iv, tag, data: [encData] }
+    const decrypted = AES.decryptGCM(ciphertext, sharedKey)
+    const random = uint8ArrayToHex(decrypted[0] || new Uint8Array(16))
+
+    // Legacy notes can only be ERC20
+    const tokenData: TokenData = {
+      tokenType: 0, // ERC20
+      tokenAddress: data.tokenHash,
+      tokenSubID: '0x00'
+    }
+
+    const receiverAddressData: AddressData = {
+      masterPublicKey: 0n,
+      viewingPublicKey: hexToUint8Array(data.recipientAddress)
+    }
+
+    const hash = getNoteHash(data.npk, tokenData, BigInt(data.value))
+
+    return new TransactNote(
+      data.npk,
+      BigInt(data.value),
+      tokenData,
+      random,
+      hash,
+      receiverAddressData,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      data.memoText,
+      undefined,
+      data.blockNumber
+    )
+  }
+}
+
+/**
+ * Checks if a serialized note is in legacy format.
+ * @param noteData - The serialized note data
+ * @returns True if legacy format, false otherwise
+ */
+function isLegacyTransactNote (noteData: any): boolean {
+  return 'encryptedRandom' in noteData
+}
+
+/**
+ * Converts ciphertext to encrypted random data format [ivTag, data].
+ * @param ciphertext - The ciphertext object
+ * @returns Tuple of [ivTag, data]
+ */
+function ciphertextToEncryptedRandomData (ciphertext: LegacyCiphertext): EncryptedData {
+  const ivTag = ciphertext.iv + ciphertext.tag
+  const data = ciphertext.data[0] || ''
+  return [ivTag, data]
+}
+
+/**
+ * Converts encrypted random data format to ciphertext object.
+ * @param encryptedRandom - Tuple of [ivTag, data]
+ * @returns Ciphertext object
+ */
+function encryptedDataToCiphertext (encryptedRandom: EncryptedData): LegacyCiphertext {
+  const [ivTag, data] = encryptedRandom
+  return {
+    iv: ivTag.slice(0, 32),
+    tag: ivTag.slice(32),
+    data: [data]
+  }
+}
+
+export {
+  TransactNote,
+  isLegacyTransactNote,
+  ciphertextToEncryptedRandomData,
+  encryptedDataToCiphertext
+}

--- a/src/notes/unshield-note.ts
+++ b/src/notes/unshield-note.ts
@@ -1,0 +1,144 @@
+import { decode, encode } from '@msgpack/msgpack'
+
+import { uint8ArrayToHex } from '../hash.js'
+
+import type { TokenData, TokenType, UnshieldData } from './definitions.js'
+import { getNoteHash } from './note-utils.js'
+import { Note } from './note.js'
+import { deserializeTokenData } from './token-utils.js'
+
+/**
+ * Represents an Unshield note with destination address.
+ */
+class UnshieldNote extends Note {
+  /**
+   * The destination address for unshielding
+   */
+  toAddress: string
+
+  /**
+   * The note hash as a bigint
+   */
+  hash: bigint
+
+  /**
+   * Whether to allow override
+   */
+  allowOverride: boolean
+
+  /**
+   * Constructs a new UnshieldNote instance.
+   * @param notePublicKey - The note public key (same as toAddress)
+   * @param value - The note value
+   * @param tokenData - The token data
+   * @param random - Random value (16 bytes hex string)
+   * @param toAddress - The destination address
+   * @param hash - The note hash
+   * @param allowOverride - Whether to allow override
+   */
+  constructor (
+    notePublicKey: string,
+    value: bigint,
+    tokenData: TokenData,
+    random: string,
+    toAddress: string,
+    hash: bigint,
+    allowOverride: boolean
+  ) {
+    super(notePublicKey, value, tokenData, random)
+    this.toAddress = toAddress
+    this.hash = hash
+    this.allowOverride = allowOverride
+  }
+
+  /**
+   * Serializes the unshield note to a Uint8Array using msgpack encoding.
+   * @returns The serialized unshield note
+   */
+  serialize (): Uint8Array {
+    return encode({
+      random: this.random,
+      toAddress: this.toAddress,
+      notePublicKey: this.notePublicKey,
+      value: this.value.toString(),
+      hash: this.hash.toString(),
+      allowOverride: this.allowOverride,
+      token: {
+        tokenAddress: this.tokenData.tokenAddress,
+        tokenType: this.tokenData.tokenType,
+        tokenSubID: this.tokenData.tokenSubID,
+      },
+    })
+  }
+
+  /**
+   * Deserializes an unshield note from a Uint8Array.
+   * @param bytes - The serialized unshield note data
+   * @returns A new UnshieldNote instance
+   */
+  static deserialize (bytes: Uint8Array): UnshieldNote {
+    const { notePublicKey, random, value, token, toAddress, hash, allowOverride } = decode(bytes) as any
+
+    return new UnshieldNote(
+      notePublicKey,
+      BigInt(value),
+      deserializeTokenData(token),
+      random,
+      toAddress,
+      BigInt(hash),
+      allowOverride
+    )
+  }
+
+  /**
+   * Creates an UnshieldNote from unshield data.
+   * NOTE: Requires cryptography libraries to be initialized first via initializeCryptographyLibs()
+   * @param unshield - The Unshield object
+   * @param random - Random value (16 bytes hex string)
+   * @returns A new UnshieldNote instance
+   * @throws {Error} If required fields are missing or poseidon is not initialized
+   */
+  static fromUnshield (
+    unshield: UnshieldData,
+    random: string
+  ): UnshieldNote {
+    const { to, token: { tokenAddress, tokenSubID, tokenType }, amount } = unshield
+
+    // Convert tokenType string to TokenType enum number
+    let tokenTypeNum: TokenType
+    switch (tokenType.toUpperCase()) {
+      case 'ERC20':
+        tokenTypeNum = 0 // TokenType.ERC20
+        break
+      case 'ERC721':
+        tokenTypeNum = 1 // TokenType.ERC721
+        break
+      case 'ERC1155':
+        tokenTypeNum = 2 // TokenType.ERC1155
+        break
+      default:
+        throw new Error(`Invalid tokenType: ${tokenType}`)
+    }
+
+    const tokenData: TokenData = {
+      tokenType: tokenTypeNum,
+      tokenAddress: uint8ArrayToHex(tokenAddress),
+      tokenSubID: uint8ArrayToHex(tokenSubID),
+    }
+
+    const toAddress = uint8ArrayToHex(to)
+    const hash = getNoteHash(toAddress, tokenData, amount)
+
+    return new UnshieldNote(
+      toAddress,
+      amount,
+      tokenData,
+      random,
+      toAddress,
+      hash,
+      false // Default value
+    )
+  }
+}
+
+export { UnshieldNote }


### PR DESCRIPTION
## Summary
- Add comprehensive type definitions (TokenType, OutputType, NoteBase, TransactNote, etc.)
- Implement token utility functions (hashing, serialization, formatting)
- Implement note hash computation and random generation utilities
- Add base Note class and derived classes (ShieldNote, TransactNote, UnshieldNote)
- Add commitment decryption logic for receiver/sender key trials
- Add `@msgpack/msgpack` dependency for note serialization

## Changes
- `src/notes/definitions.ts` — all type definitions, enums, constants
- `src/notes/token-utils.ts` — token hashing, serialization, formatting
- `src/notes/note-utils.ts` — note hash computation, random generation
- `src/notes/note.ts` — base Note class
- `src/notes/shield-note.ts` — ShieldNote class
- `src/notes/transact-note.ts` — TransactNote class + serialization helpers
- `src/notes/unshield-note.ts` — UnshieldNote class
- `src/notes/decrypt-commitment.ts` — commitment decryption logic
- `src/notes/index.ts` — barrel exports
- `src/index.ts` — add notes and keys re-exports
- `package.json` — add @msgpack/msgpack dependency

## Stacked PR
This is **PR 3 of 4** in the note-types split:
1. #6 — Config/tooling
2. #7 — JSDoc improvements + hex conversion utilities
3. **This PR** — Note types, token utils, and note classes
4. #→ `pr/tests` — Comprehensive test suite

**Base:** `pr/jsdoc-hex-utils` (PR #7)

## Test plan
- [ ] `npm run build` succeeds
- [ ] Types are correctly exported from package index
- [ ] Note classes can be instantiated with valid data