### PR TITLE
test: add comprehensive test suite for all wallet-node modules

### DIFF
--- a/test/derive.test.ts
+++ b/test/derive.test.ts
@@ -1,0 +1,98 @@
+import { test } from 'brittle'
+
+import { DERIVATION_PATH_PREFIXES, deriveNodes, derivePathsForIndex } from '../src/derive'
+import { initializeCryptographyLibs } from '../src/keys'
+
+const TEST_MNEMONIC = 'test test test test test test test test test test test junk'
+
+test('derive - DERIVATION_PATH_PREFIXES', (t) => {
+  t.is(DERIVATION_PATH_PREFIXES.SPENDING, "m/44'/1984'/0'/0'/", 'should have correct spending prefix')
+  t.is(DERIVATION_PATH_PREFIXES.VIEWING, "m/420'/1984'/0'/0'/", 'should have correct viewing prefix')
+})
+
+test('derive - derivePathsForIndex with default index', (t) => {
+  const paths = derivePathsForIndex()
+
+  t.is(paths.spending, "m/44'/1984'/0'/0'/0'", 'should generate correct spending path for index 0')
+  t.is(paths.viewing, "m/420'/1984'/0'/0'/0'", 'should generate correct viewing path for index 0')
+})
+
+test('derive - derivePathsForIndex with custom index', (t) => {
+  const paths1 = derivePathsForIndex(1)
+  t.is(paths1.spending, "m/44'/1984'/0'/0'/1'", 'should generate correct spending path for index 1')
+  t.is(paths1.viewing, "m/420'/1984'/0'/0'/1'", 'should generate correct viewing path for index 1')
+
+  const paths5 = derivePathsForIndex(5)
+  t.is(paths5.spending, "m/44'/1984'/0'/0'/5'", 'should generate correct spending path for index 5')
+  t.is(paths5.viewing, "m/420'/1984'/0'/0'/5'", 'should generate correct viewing path for index 5')
+
+  const paths100 = derivePathsForIndex(100)
+  t.is(paths100.spending, "m/44'/1984'/0'/0'/100'", 'should generate correct spending path for index 100')
+  t.is(paths100.viewing, "m/420'/1984'/0'/0'/100'", 'should generate correct viewing path for index 100')
+})
+
+test('derive - deriveNodes with default index', async (t) => {
+  await initializeCryptographyLibs()
+
+  const nodes = deriveNodes(TEST_MNEMONIC)
+
+  t.ok(nodes.spending, 'should return spending node')
+  t.ok(nodes.viewing, 'should return viewing node')
+  t.ok(typeof nodes.spending.getSpendingKeyPair === 'function', 'spending node should have getSpendingKeyPair method')
+  t.ok(typeof nodes.viewing.getViewingKeyPair === 'function', 'viewing node should have getViewingKeyPair method')
+})
+
+test('derive - deriveNodes with custom index', async (t) => {
+  await initializeCryptographyLibs()
+
+  const nodes0 = deriveNodes(TEST_MNEMONIC, 0)
+  const nodes1 = deriveNodes(TEST_MNEMONIC, 1)
+
+  const spendingKey0 = nodes0.spending.getSpendingKeyPair()
+  const spendingKey1 = nodes1.spending.getSpendingKeyPair()
+
+  t.not(spendingKey0.privateKey, spendingKey1.privateKey, 'should generate different keys for different indices')
+})
+
+test('derive - deriveNodes deterministic', async (t) => {
+  await initializeCryptographyLibs()
+
+  const nodes1 = deriveNodes(TEST_MNEMONIC, 0)
+  const nodes2 = deriveNodes(TEST_MNEMONIC, 0)
+
+  const spendingKey1 = nodes1.spending.getSpendingKeyPair()
+  const spendingKey2 = nodes2.spending.getSpendingKeyPair()
+
+  t.alike(spendingKey1.privateKey, spendingKey2.privateKey, 'should generate same keys for same mnemonic and index')
+})
+
+test('derive - deriveNodes with different mnemonics', async (t) => {
+  await initializeCryptographyLibs()
+
+  const mnemonic1 = 'test test test test test test test test test test test junk'
+  const mnemonic2 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+  const nodes1 = deriveNodes(mnemonic1, 0)
+  const nodes2 = deriveNodes(mnemonic2, 0)
+
+  const spendingKey1 = nodes1.spending.getSpendingKeyPair()
+  const spendingKey2 = nodes2.spending.getSpendingKeyPair()
+
+  t.not(spendingKey1.privateKey, spendingKey2.privateKey, 'should generate different keys for different mnemonics')
+})
+
+test('derive - multiple derivation indices', async (t) => {
+  await initializeCryptographyLibs()
+
+  const indices = [0, 1, 2, 5, 10, 100]
+  const keys = new Set()
+
+  for (const index of indices) {
+    const nodes = deriveNodes(TEST_MNEMONIC, index)
+    const spendingKey = nodes.spending.getSpendingKeyPair()
+    const keyString = Buffer.from(spendingKey.privateKey).toString('hex')
+    keys.add(keyString)
+  }
+
+  t.is(keys.size, indices.length, 'should generate unique keys for each index')
+})

--- a/test/hash.test.ts
+++ b/test/hash.test.ts
@@ -1,0 +1,93 @@
+import { test } from 'brittle'
+
+import {
+  bigintToUint8Array,
+  encodeBytes,
+  hexToArray,
+  sha512HMAC,
+  uint8ArrayToBigInt,
+  xorBytesInPlace
+} from '../src/hash'
+
+test('hash - sha512HMAC', (t) => {
+  const key = new Uint8Array([1, 2, 3, 4])
+  const data = new Uint8Array([5, 6, 7, 8])
+  const result = sha512HMAC(key, data)
+
+  t.ok(result instanceof Uint8Array, 'should return Uint8Array')
+  t.is(result.length, 64, 'should return 64 bytes (512 bits)')
+})
+
+test('hash - encodeBytes', (t) => {
+  const vectors = [
+    { input: '', expected: new Uint8Array([]) },
+    { input: 'RAILGUN', expected: new Uint8Array([82, 65, 73, 76, 71, 85, 78]) },
+    { input: 'PRIVACY & ANONYMITY', expected: new Uint8Array([80, 82, 73, 86, 65, 67, 89, 32, 38, 32, 65, 78, 79, 78, 89, 77, 73, 84, 89]) }
+  ]
+
+  for (const vector of vectors) {
+    const result = encodeBytes(vector.input)
+    t.alike(result, vector.expected, `should encode "${vector.input}" correctly`)
+  }
+})
+
+test('hash - uint8ArrayToBigInt', (t) => {
+  const vectors = [
+    { array: new Uint8Array([1, 56, 188]), expected: BigInt('80060') },
+    { array: new Uint8Array([82, 65, 73, 76, 71, 85, 78]), expected: BigInt('23152731158435150') },
+    { array: new Uint8Array([0, 0, 0, 0]), expected: BigInt('0') }
+  ]
+
+  for (const vector of vectors) {
+    const result = uint8ArrayToBigInt(vector.array)
+    t.is(result, vector.expected, 'should convert array to bigint correctly')
+  }
+})
+
+test('hash - hexToArray', (t) => {
+  const vectors = [
+    { hex: '0138bc', expected: new Uint8Array([1, 56, 188]) },
+    { hex: '5241494c47554e', expected: new Uint8Array([82, 65, 73, 76, 71, 85, 78]) },
+    { hex: '50524956414359202620414e4f4e594d495459', expected: new Uint8Array([80, 82, 73, 86, 65, 67, 89, 32, 38, 32, 65, 78, 79, 78, 89, 77, 73, 84, 89]) }
+  ]
+
+  for (const vector of vectors) {
+    const result = hexToArray(vector.hex)
+    t.alike(result, vector.expected, `should convert hex "${vector.hex}" to array correctly`)
+  }
+})
+
+test('hash - hexToArray error on odd length', (t) => {
+  t.exception(() => {
+    hexToArray('abc')
+  }, 'should throw error for odd length hex string')
+})
+
+test('hash - bigintToUint8Array', (t) => {
+  const value = BigInt('256')
+  const result = bigintToUint8Array(value)
+
+  t.ok(result instanceof Uint8Array, 'should return Uint8Array')
+  t.is(result.length, 32, 'should return 32 bytes by default')
+
+  const result16 = bigintToUint8Array(value, 16)
+  t.is(result16.length, 16, 'should return 16 bytes when specified')
+})
+
+test('hash - xorBytesInPlace', (t) => {
+  const a = new Uint8Array([0xFF, 0x00, 0xAA])
+  const b = new Uint8Array([0x0F, 0xF0, 0x55])
+  const output = new Uint8Array(3)
+
+  xorBytesInPlace(a, b, output, 0)
+
+  t.alike(output, new Uint8Array([0xF0, 0xF0, 0xFF]), 'should XOR bytes correctly')
+})
+
+test('hash - round trip conversions', (t) => {
+  const testBigInt = BigInt('1234567890')
+  const asArray = bigintToUint8Array(testBigInt, 32)
+  const backToBigInt = uint8ArrayToBigInt(asArray)
+
+  t.is(backToBigInt, testBigInt, 'should convert bigint to array and back')
+})

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -1,0 +1,247 @@
+import { test } from 'brittle'
+
+import {
+  adjustBytes25519,
+  getBlindingScalar,
+  getNoteBlindingKeys,
+  getPrivateScalarFromPrivateKey,
+  getPublicSpendingKey,
+  getPublicViewingKey,
+  getRandomScalar,
+  getSharedSymmetricKey,
+  initializeCryptographyLibs,
+  seedToScalar,
+  unblindNoteKey,
+} from '../src/keys'
+
+test('keys - initialization', async (t) => {
+  t.plan(1)
+  await initializeCryptographyLibs()
+  t.pass('should initialize cryptography libraries without error')
+})
+
+test('keys - getPublicSpendingKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const privateKey = new Uint8Array(32)
+  privateKey.fill(1)
+
+  const publicKey = getPublicSpendingKey(privateKey)
+
+  t.ok(Array.isArray(publicKey), 'should return an array')
+  t.is(publicKey.length, 2, 'should return array with 2 elements')
+  t.ok(publicKey[0] instanceof Uint8Array, 'first element should be Uint8Array')
+  t.ok(publicKey[1] instanceof Uint8Array, 'second element should be Uint8Array')
+})
+
+test('keys - getPublicSpendingKey error on invalid length', async (t) => {
+  await initializeCryptographyLibs()
+
+  const invalidKey = new Uint8Array(16) // Wrong length
+
+  t.exception(() => {
+    getPublicSpendingKey(invalidKey)
+  }, 'should throw error for invalid private key length')
+})
+
+test('keys - getPublicViewingKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const privateViewingKey = new Uint8Array(32)
+  privateViewingKey.fill(2)
+
+  const publicViewingKey = getPublicViewingKey(privateViewingKey)
+
+  t.ok(publicViewingKey instanceof Uint8Array, 'should return Uint8Array')
+  t.is(publicViewingKey.length, 32, 'should return 32 bytes')
+})
+
+test('keys - adjustBytes25519 little endian', async (t) => {
+  const bytes = new Uint8Array(32)
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = i
+  }
+
+  const adjusted: Uint8Array = adjustBytes25519(bytes, 'le')
+
+  t.ok(adjusted instanceof Uint8Array, 'should return Uint8Array')
+  t.is(adjusted.length, 32, 'should return 32 bytes')
+  t.is(adjusted[0]! & 0b00000111, 0, 'should clear last 3 bits of first byte')
+  t.is(adjusted[31]! & 0b10000000, 0, 'should clear first bit of last byte')
+  t.is(adjusted[31]! & 0b01000000, 0b01000000, 'should set second bit of last byte')
+})
+
+test('keys - adjustBytes25519 big endian', async (t) => {
+  const bytes = new Uint8Array(32)
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = i
+  }
+
+  const adjusted: Uint8Array = adjustBytes25519(bytes, 'be')
+
+  t.ok(adjusted instanceof Uint8Array, 'should return Uint8Array')
+  t.is(adjusted.length, 32, 'should return 32 bytes')
+  t.is(adjusted[31]! & 0b00000111, 0, 'should clear last 3 bits of last byte')
+  t.is(adjusted[0]! & 0b10000000, 0, 'should clear first bit of first byte')
+  t.is(adjusted[0]! & 0b01000000, 0b01000000, 'should set second bit of first byte')
+})
+
+test('keys - adjustBytes25519 error on invalid input', async (t) => {
+  t.exception(() => {
+    adjustBytes25519(new Uint8Array(16), 'le')
+  }, 'should throw error for invalid byte length')
+})
+
+test('keys - getPrivateScalarFromPrivateKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const privateKey = new Uint8Array(32)
+  privateKey.fill(5)
+
+  const scalar = await getPrivateScalarFromPrivateKey(privateKey)
+
+  t.ok(scalar instanceof Uint8Array, 'should return Uint8Array')
+  t.is(scalar.length, 32, 'should return 32 bytes')
+})
+
+test('keys - getPrivateScalarFromPrivateKey error on invalid length', async (t) => {
+  await initializeCryptographyLibs()
+
+  await t.exception(async () => {
+    await getPrivateScalarFromPrivateKey(new Uint8Array(16))
+  }, 'should throw error for invalid private key length')
+})
+
+test('keys - getRandomScalar', async (t) => {
+  await initializeCryptographyLibs()
+
+  const scalar1 = getRandomScalar()
+  const scalar2 = getRandomScalar()
+
+  t.ok(scalar1 instanceof Uint8Array, 'should return Uint8Array')
+  t.ok(scalar2 instanceof Uint8Array, 'should return Uint8Array')
+  t.not(scalar1, scalar2, 'should generate different random scalars')
+})
+
+test('keys - seedToScalar', async (t) => {
+  await initializeCryptographyLibs()
+
+  const seed = new Uint8Array(32)
+  seed.fill(10)
+
+  const scalar = seedToScalar(seed)
+
+  t.ok(scalar instanceof Uint8Array, 'should return Uint8Array')
+  t.is(scalar.length, 32, 'should return 32 bytes')
+})
+
+test('keys - getBlindingScalar', async (t) => {
+  await initializeCryptographyLibs()
+
+  const sharedRandom = new Uint8Array(32)
+  sharedRandom.fill(1)
+
+  const senderRandom = new Uint8Array(32)
+  senderRandom.fill(2)
+
+  const blindingScalar = getBlindingScalar(sharedRandom, senderRandom)
+
+  t.is(typeof blindingScalar, 'bigint', 'should return bigint')
+  t.ok(blindingScalar > 0n, 'should return positive bigint')
+})
+
+test('keys - getNoteBlindingKeys', async (t) => {
+  await initializeCryptographyLibs()
+
+  const senderViewingPublicKey = new Uint8Array(32)
+  senderViewingPublicKey.fill(1)
+  const senderPublicKey = getPublicViewingKey(senderViewingPublicKey)
+
+  const receiverViewingPublicKey = new Uint8Array(32)
+  receiverViewingPublicKey.fill(2)
+  const receiverPublicKey = getPublicViewingKey(receiverViewingPublicKey)
+
+  const sharedRandom = new Uint8Array(32)
+  sharedRandom.fill(3)
+
+  const senderRandom = new Uint8Array(32)
+  senderRandom.fill(4)
+
+  const result = getNoteBlindingKeys(
+    senderPublicKey,
+    receiverPublicKey,
+    sharedRandom,
+    senderRandom
+  )
+
+  t.ok(result.blindedSenderViewingKey instanceof Uint8Array, 'should return blinded sender key')
+  t.ok(result.blindedReceiverViewingKey instanceof Uint8Array, 'should return blinded receiver key')
+  t.is(result.blindedSenderViewingKey.length, 32, 'blinded sender key should be 32 bytes')
+  t.is(result.blindedReceiverViewingKey.length, 32, 'blinded receiver key should be 32 bytes')
+})
+
+test('keys - unblindNoteKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  // Create test keys
+  const privateKey = new Uint8Array(32)
+  privateKey.fill(1)
+  const publicKey = getPublicViewingKey(privateKey)
+
+  const sharedRandom = new Uint8Array(32)
+  sharedRandom.fill(3)
+
+  const senderRandom = new Uint8Array(32)
+  senderRandom.fill(4)
+
+  // Blind the key
+  const privateKey2 = new Uint8Array(32)
+  privateKey2.fill(2)
+  const publicKey2 = getPublicViewingKey(privateKey2)
+
+  const { blindedReceiverViewingKey } = getNoteBlindingKeys(
+    publicKey,
+    publicKey2,
+    sharedRandom,
+    senderRandom
+  )
+
+  // Unblind it
+  const unblinded = unblindNoteKey(blindedReceiverViewingKey, sharedRandom, senderRandom)
+
+  t.ok(unblinded instanceof Uint8Array || unblinded === undefined, 'should return Uint8Array or undefined')
+  if (unblinded) {
+    t.is(unblinded.length, 32, 'unblinded key should be 32 bytes')
+  }
+})
+
+test('keys - getSharedSymmetricKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const privateKeyA = new Uint8Array(32)
+  privateKeyA.fill(1)
+
+  const privateKeyB = new Uint8Array(32)
+  privateKeyB.fill(2)
+  const publicKeyB = getPublicViewingKey(privateKeyB)
+
+  const sharedKey = await getSharedSymmetricKey(privateKeyA, publicKeyB)
+
+  t.ok(sharedKey instanceof Uint8Array || sharedKey === undefined, 'should return Uint8Array or undefined')
+  if (sharedKey) {
+    t.is(sharedKey.length, 32, 'shared key should be 32 bytes')
+  }
+})
+
+test('keys - deterministic key generation', async (t) => {
+  await initializeCryptographyLibs()
+
+  const privateKey = new Uint8Array(32)
+  privateKey.fill(42)
+
+  const publicKey1 = getPublicSpendingKey(privateKey)
+  const publicKey2 = getPublicSpendingKey(privateKey)
+
+  t.alike(publicKey1[0], publicKey2[0], 'should generate same public key from same private key')
+  t.alike(publicKey1[1], publicKey2[1], 'should generate same public key from same private key')
+})

--- a/test/notes.test.ts
+++ b/test/notes.test.ts
@@ -1,0 +1,1529 @@
+import { randomBytes } from '@noble/hashes/utils'
+import { AES } from '@railgun-reloaded/cryptography'
+import { test } from 'brittle'
+
+import {
+  bigintToUint8Array,
+  hexToUint8Array,
+  uint8ArrayToHex,
+} from '../src/hash'
+import {
+  getNoteBlindingKeys,
+  getPublicViewingKey,
+  getSharedSymmetricKey,
+  initializeCryptographyLibs,
+} from '../src/keys'
+import {
+  decryptCommitment,
+  decryptCommitmentAsReceiverOrSender,
+} from '../src/notes/decrypt-commitment'
+import { assertValidNoteRandom, getNoteHash } from '../src/notes/note-utils'
+import { ShieldNote } from '../src/notes/shield-note'
+import {
+  assertValidNoteToken,
+  computeTokenHash,
+  computeTokenHashERC20,
+  computeTokenHashNFT,
+  deserializeTokenData,
+  getReadableTokenAddress,
+  serializeTokenData,
+} from '../src/notes/token-utils'
+import {
+  TransactNote,
+  ciphertextToEncryptedRandomData,
+  encryptedDataToCiphertext,
+  isLegacyTransactNote,
+} from '../src/notes/transact-note'
+import { UnshieldNote } from '../src/notes/unshield-note'
+
+const TEST_TOKEN_ADDRESS = '0x1234567890123456789012345678901234567890'
+const TEST_TOKEN_SUB_ID_ZERO =
+  '0x0000000000000000000000000000000000000000000000000000000000000000'
+const TEST_NPK =
+  '0x1234567890123456789012345678901234567890123456789012345678901234'
+const TEST_RANDOM = '12345678901234567890123456789012'
+const TEST_VALUE = BigInt('1000000000000000000') // 1 ETH
+
+const ERC20_TOKEN_DATA = {
+  tokenType: 0,
+  tokenAddress: TEST_TOKEN_ADDRESS,
+  tokenSubID: TEST_TOKEN_SUB_ID_ZERO,
+}
+
+const ERC721_TOKEN_DATA = {
+  tokenType: 1,
+  tokenAddress: TEST_TOKEN_ADDRESS,
+  tokenSubID:
+    '0x0000000000000000000000000000000000000000000000000000000000000001',
+}
+
+const ERC1155_TOKEN_DATA = {
+  tokenType: 2,
+  tokenAddress: TEST_TOKEN_ADDRESS,
+  tokenSubID:
+    '0x0000000000000000000000000000000000000000000000000000000000000005',
+}
+
+test('token-utils - computeTokenHash ERC20 known vector', (t) => {
+  const hash = computeTokenHash(ERC20_TOKEN_DATA)
+
+  // ERC20 hash is the address zero-padded to 32 bytes
+  t.is(
+    hash,
+    '0x0000000000000000000000001234567890123456789012345678901234567890',
+    'ERC20 hash should be zero-padded address'
+  )
+})
+
+test('token-utils - computeTokenHash ERC721 known vector', (t) => {
+  const hash = computeTokenHash(ERC721_TOKEN_DATA)
+
+  // Known keccak256-based hash for this token data, mod SNARK_PRIME
+  t.is(
+    hash,
+    '0x075b737079de804169d5e006add4da4942063ab4fce32268c469c49460e52be0',
+    'ERC721 hash should match known vector'
+  )
+})
+
+test('token-utils - computeTokenHash ERC1155 known vector', (t) => {
+  const hash = computeTokenHash(ERC1155_TOKEN_DATA)
+
+  t.is(
+    hash,
+    '0x03b8bfbf662863b2da6422aa0d1f021639ca87ae10d85bdf48069c2e98c72d6a',
+    'ERC1155 hash should match known vector'
+  )
+})
+
+test('token-utils - computeTokenHash invalid token type', (t) => {
+  const tokenData = {
+    tokenType: 99,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: TEST_TOKEN_SUB_ID_ZERO,
+  }
+
+  t.exception(() => {
+    computeTokenHash(tokenData)
+  }, 'should throw error for invalid token type')
+})
+
+test('token-utils - computeTokenHash deterministic', (t) => {
+  const hash1 = computeTokenHash(ERC20_TOKEN_DATA)
+  const hash2 = computeTokenHash(ERC20_TOKEN_DATA)
+
+  t.is(hash1, hash2, 'should generate same hash for same token data')
+})
+
+test('token-utils - computeTokenHashERC20 direct', (t) => {
+  const hash = computeTokenHashERC20(TEST_TOKEN_ADDRESS)
+
+  t.is(
+    hash,
+    '0x0000000000000000000000001234567890123456789012345678901234567890',
+    'should zero-pad address to 32 bytes'
+  )
+})
+
+test('token-utils - computeTokenHashERC20 without 0x prefix', (t) => {
+  const hash = computeTokenHashERC20(
+    '1234567890123456789012345678901234567890'
+  )
+
+  t.is(
+    hash,
+    '0x0000000000000000000000001234567890123456789012345678901234567890',
+    'should handle address without 0x prefix'
+  )
+})
+
+test('token-utils - computeTokenHashNFT different subIDs', (t) => {
+  const hash1 = computeTokenHashNFT(ERC721_TOKEN_DATA)
+  const hash2 = computeTokenHashNFT({
+    ...ERC721_TOKEN_DATA,
+    tokenSubID:
+      '0x0000000000000000000000000000000000000000000000000000000000000002',
+  })
+
+  t.not(hash1, hash2, 'different subIDs should produce different hashes')
+})
+
+test('token-utils - getReadableTokenAddress ERC20 known vector', (t) => {
+  const readable = getReadableTokenAddress(ERC20_TOKEN_DATA)
+
+  t.is(
+    readable,
+    '0x1234567890123456789012345678901234567890',
+    'ERC20 readable should be trimmed 20-byte address'
+  )
+})
+
+test('token-utils - getReadableTokenAddress NFT known vector', (t) => {
+  const readable = getReadableTokenAddress(ERC721_TOKEN_DATA)
+
+  t.is(
+    readable,
+    '0x1234567890123456789012345678901234567890 (0x0000000000000000000000000000000000000000000000000000000000000001)',
+    'NFT readable should include address and subID'
+  )
+})
+
+test('token-utils - getReadableTokenAddress invalid type', (t) => {
+  t.exception(() => {
+    getReadableTokenAddress({
+      tokenType: 99 as any,
+      tokenAddress: TEST_TOKEN_ADDRESS,
+      tokenSubID: TEST_TOKEN_SUB_ID_ZERO,
+    })
+  }, 'should throw for invalid token type')
+})
+
+test('token-utils - serializeTokenData roundtrip ERC20', (t) => {
+  const serialized = serializeTokenData(ERC20_TOKEN_DATA)
+  const deserialized = deserializeTokenData(serialized)
+
+  t.is(
+    deserialized.tokenType,
+    ERC20_TOKEN_DATA.tokenType,
+    'should preserve tokenType'
+  )
+  t.is(
+    deserialized.tokenAddress,
+    ERC20_TOKEN_DATA.tokenAddress,
+    'should preserve tokenAddress'
+  )
+  t.is(
+    deserialized.tokenSubID,
+    ERC20_TOKEN_DATA.tokenSubID,
+    'should preserve tokenSubID'
+  )
+})
+
+test('token-utils - serializeTokenData roundtrip ERC721', (t) => {
+  const serialized = serializeTokenData(ERC721_TOKEN_DATA)
+  const deserialized = deserializeTokenData(serialized)
+
+  t.is(
+    deserialized.tokenType,
+    ERC721_TOKEN_DATA.tokenType,
+    'should preserve tokenType'
+  )
+  t.is(
+    deserialized.tokenAddress,
+    ERC721_TOKEN_DATA.tokenAddress,
+    'should preserve tokenAddress'
+  )
+  t.is(
+    deserialized.tokenSubID,
+    ERC721_TOKEN_DATA.tokenSubID,
+    'should preserve tokenSubID'
+  )
+})
+
+test('token-utils - serializeTokenData roundtrip ERC1155', (t) => {
+  const serialized = serializeTokenData(ERC1155_TOKEN_DATA)
+  const deserialized = deserializeTokenData(serialized)
+
+  t.is(
+    deserialized.tokenType,
+    ERC1155_TOKEN_DATA.tokenType,
+    'should preserve tokenType'
+  )
+  t.is(
+    deserialized.tokenAddress,
+    ERC1155_TOKEN_DATA.tokenAddress,
+    'should preserve tokenAddress'
+  )
+  t.is(
+    deserialized.tokenSubID,
+    ERC1155_TOKEN_DATA.tokenSubID,
+    'should preserve tokenSubID'
+  )
+})
+
+test('token-utils - assertValidNoteToken ERC20 valid', (t) => {
+  t.execution(() => {
+    assertValidNoteToken(ERC20_TOKEN_DATA, TEST_VALUE)
+  }, 'should not throw for valid ERC20')
+})
+
+test('token-utils - assertValidNoteToken ERC20 valid 64-char address', (t) => {
+  const tokenData = {
+    tokenType: 0,
+    tokenAddress: '0x' + '12'.repeat(32),
+    tokenSubID: '0x0',
+  }
+  t.execution(() => {
+    assertValidNoteToken(tokenData, TEST_VALUE)
+  }, 'should accept 64-char (32-byte) ERC20 address')
+})
+
+test('token-utils - assertValidNoteToken ERC20 invalid address length', (t) => {
+  const tokenData = {
+    tokenType: 0,
+    tokenAddress: '0x1234', // too short
+    tokenSubID: '0x0',
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, TEST_VALUE)
+  }, 'should throw for invalid ERC20 address length')
+})
+
+test('token-utils - assertValidNoteToken ERC20 non-zero subID', (t) => {
+  const tokenData = {
+    tokenType: 0,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: '0x1',
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, TEST_VALUE)
+  }, 'should throw for ERC20 with non-zero subID')
+})
+
+test('token-utils - assertValidNoteToken ERC721 valid', (t) => {
+  const tokenData = {
+    tokenType: 1,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: '0x1',
+  }
+  t.execution(() => {
+    assertValidNoteToken(tokenData, 1n)
+  }, 'should not throw for valid ERC721')
+})
+
+test('token-utils - assertValidNoteToken ERC721 missing subID', (t) => {
+  const tokenData = {
+    tokenType: 1,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: '0x0',
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, 1n)
+  }, 'should throw for ERC721 without subID')
+})
+
+test('token-utils - assertValidNoteToken ERC721 wrong value', (t) => {
+  const tokenData = {
+    tokenType: 1,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: '0x1',
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, 2n)
+  }, 'should throw for ERC721 with value != 1')
+})
+
+test('token-utils - assertValidNoteToken ERC721 invalid address length', (t) => {
+  const tokenData = {
+    tokenType: 1,
+    tokenAddress: '0x' + '12'.repeat(32), // 64 chars, not 40
+    tokenSubID: '0x1',
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, 1n)
+  }, 'should throw for ERC721 with non-20-byte address')
+})
+
+test('token-utils - assertValidNoteToken ERC1155 valid', (t) => {
+  const tokenData = {
+    tokenType: 2,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: '0x5',
+  }
+  t.execution(() => {
+    assertValidNoteToken(tokenData, 100n)
+  }, 'should not throw for valid ERC1155')
+})
+
+test('token-utils - assertValidNoteToken ERC1155 missing subID', (t) => {
+  const tokenData = {
+    tokenType: 2,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: '0x0',
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, 100n)
+  }, 'should throw for ERC1155 without subID')
+})
+
+test('token-utils - assertValidNoteToken invalid token type', (t) => {
+  const tokenData = {
+    tokenType: 99,
+    tokenAddress: TEST_TOKEN_ADDRESS,
+    tokenSubID: TEST_TOKEN_SUB_ID_ZERO,
+  }
+  t.exception(() => {
+    assertValidNoteToken(tokenData, TEST_VALUE)
+  }, 'should throw for invalid token type')
+})
+
+test('note-utils - assertValidNoteRandom valid', (t) => {
+  t.execution(() => {
+    assertValidNoteRandom(TEST_RANDOM)
+  }, 'should not throw for valid random')
+
+  t.execution(() => {
+    assertValidNoteRandom('0x' + TEST_RANDOM)
+  }, 'should not throw for valid random with 0x prefix')
+})
+
+test('note-utils - assertValidNoteRandom invalid length', (t) => {
+  t.exception(() => {
+    assertValidNoteRandom('0x12345678')
+  }, 'should throw for short random')
+
+  t.exception(() => {
+    assertValidNoteRandom('0x' + '12'.repeat(100))
+  }, 'should throw for long random')
+})
+
+test('note-utils - getNoteHash known vector', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = getNoteHash(
+    TEST_NPK,
+    ERC20_TOKEN_DATA,
+    BigInt('1000000000000000000')
+  )
+
+  t.is(
+    hash,
+    7822264150748016131168246751038092891550418438611309934403065338118898163274n,
+    'should match known poseidon hash'
+  )
+})
+
+test('note-utils - getNoteHash deterministic', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash1 = getNoteHash(TEST_NPK, ERC20_TOKEN_DATA, TEST_VALUE)
+  const hash2 = getNoteHash(TEST_NPK, ERC20_TOKEN_DATA, TEST_VALUE)
+
+  t.is(hash1, hash2, 'should generate same hash for same inputs')
+})
+
+test('note-utils - getNoteHash different values produce different hashes', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash1 = getNoteHash(
+    TEST_NPK,
+    ERC20_TOKEN_DATA,
+    BigInt('1000000000000000000')
+  )
+  const hash2 = getNoteHash(
+    TEST_NPK,
+    ERC20_TOKEN_DATA,
+    BigInt('2000000000000000000')
+  )
+
+  t.is(
+    hash1,
+    7822264150748016131168246751038092891550418438611309934403065338118898163274n,
+    'hash1 should match known vector'
+  )
+  t.is(
+    hash2,
+    6490590858878968097404251785480759231009497191854530268680734263829621455840n,
+    'hash2 should match known vector'
+  )
+  t.not(hash1, hash2, 'should generate different hashes for different values')
+})
+
+test('note-utils - getNoteHash different addresses produce different hashes', async (t) => {
+  await initializeCryptographyLibs()
+
+  const address2 =
+    '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+  const hash1 = getNoteHash(TEST_NPK, ERC20_TOKEN_DATA, TEST_VALUE)
+  const hash2 = getNoteHash(address2, ERC20_TOKEN_DATA, TEST_VALUE)
+
+  t.is(
+    hash2,
+    5736106082853618600278509422750779697540890231038988902514807784802527031326n,
+    'hash2 should match known vector'
+  )
+  t.not(
+    hash1,
+    hash2,
+    'should generate different hashes for different addresses'
+  )
+})
+
+test('shield-note - create ShieldNote', async (t) => {
+  await initializeCryptographyLibs()
+
+  const masterPublicKey = BigInt('123456789012345678901234567890')
+  const shieldNote = new ShieldNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    masterPublicKey
+  )
+
+  t.ok(shieldNote instanceof ShieldNote, 'should create ShieldNote instance')
+  t.is(shieldNote.value, TEST_VALUE, 'should set value correctly')
+  t.is(
+    shieldNote.masterPublicKey,
+    masterPublicKey,
+    'should set masterPublicKey correctly'
+  )
+  t.is(shieldNote.random, TEST_RANDOM, 'should set random correctly')
+  t.is(
+    shieldNote.notePublicKey,
+    TEST_NPK,
+    'should set notePublicKey correctly'
+  )
+  t.is(
+    shieldNote.tokenHash,
+    computeTokenHash(ERC20_TOKEN_DATA),
+    'should compute token hash'
+  )
+})
+
+test('shield-note - serialize and deserialize', async (t) => {
+  await initializeCryptographyLibs()
+
+  const masterPublicKey = BigInt('123456789012345678901234567890')
+  const shieldNote = new ShieldNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    masterPublicKey
+  )
+  const serialized = shieldNote.serialize()
+
+  t.ok(serialized instanceof Uint8Array, 'should serialize to Uint8Array')
+
+  const deserialized = ShieldNote.deserialize(serialized)
+
+  t.ok(deserialized instanceof ShieldNote, 'should deserialize to ShieldNote')
+  t.is(deserialized.value, TEST_VALUE, 'should preserve value')
+  t.is(
+    deserialized.masterPublicKey,
+    masterPublicKey,
+    'should preserve masterPublicKey'
+  )
+  t.is(deserialized.random, TEST_RANDOM, 'should preserve random')
+  t.is(deserialized.notePublicKey, TEST_NPK, 'should preserve notePublicKey')
+  t.is(
+    deserialized.tokenData.tokenType,
+    ERC20_TOKEN_DATA.tokenType,
+    'should preserve tokenType'
+  )
+  t.is(
+    deserialized.tokenData.tokenAddress,
+    ERC20_TOKEN_DATA.tokenAddress,
+    'should preserve tokenAddress'
+  )
+})
+
+test('shield-note - getTokenHash matches computeTokenHash', async (t) => {
+  await initializeCryptographyLibs()
+
+  const masterPublicKey = BigInt('123456789012345678901234567890')
+  const shieldNote = new ShieldNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    masterPublicKey
+  )
+
+  t.is(
+    shieldNote.getTokenHash(),
+    computeTokenHash(ERC20_TOKEN_DATA),
+    'getTokenHash should match computeTokenHash'
+  )
+})
+
+test('shield-note - fromCommitment with GeneratedCommitment', async (t) => {
+  await initializeCryptographyLibs()
+
+  const masterPublicKey = BigInt('999888777666555444333222111')
+  const commitment = {
+    hash: new Uint8Array(32),
+    treeNumber: 0,
+    treePosition: 0,
+    preimage: {
+      npk: hexToUint8Array('0x' + 'ab'.repeat(32)),
+      value: 5000n,
+      token: {
+        tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+        tokenType: 'ERC20',
+        tokenSubID: hexToUint8Array(TEST_TOKEN_SUB_ID_ZERO),
+      },
+    },
+    encryptedRandom: [hexToUint8Array('0x' + 'cd'.repeat(16))],
+  }
+
+  const shieldNote = ShieldNote.fromCommitment(commitment, masterPublicKey)
+
+  t.ok(
+    shieldNote instanceof ShieldNote,
+    'should create ShieldNote from GeneratedCommitment'
+  )
+  t.is(shieldNote.value, 5000n, 'should set value from preimage')
+  t.is(
+    shieldNote.masterPublicKey,
+    masterPublicKey,
+    'should set masterPublicKey from parameter'
+  )
+  t.is(
+    shieldNote.tokenData.tokenType,
+    0,
+    'should convert ERC20 string to enum'
+  )
+})
+
+test('shield-note - fromCommitment with ShieldCommitment', async (t) => {
+  await initializeCryptographyLibs()
+
+  const shieldKeyBytes = bigintToUint8Array(BigInt('112233445566778899'), 32)
+  const commitment = {
+    hash: new Uint8Array(32),
+    treeNumber: 0,
+    treePosition: 0,
+    preimage: {
+      npk: hexToUint8Array('0x' + 'ab'.repeat(32)),
+      value: 7777n,
+      token: {
+        tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+        tokenType: 'ERC721',
+        tokenSubID: hexToUint8Array(
+          '0x0000000000000000000000000000000000000000000000000000000000000001'
+        ),
+      },
+    },
+    encryptedBundle: [hexToUint8Array('0x' + 'ef'.repeat(16))],
+    shieldKey: shieldKeyBytes,
+  }
+
+  const shieldNote = ShieldNote.fromCommitment(commitment)
+
+  t.ok(
+    shieldNote instanceof ShieldNote,
+    'should create ShieldNote from ShieldCommitment'
+  )
+  t.is(shieldNote.value, 7777n, 'should set value')
+  t.is(
+    shieldNote.masterPublicKey,
+    BigInt('112233445566778899'),
+    'should extract masterPublicKey from shieldKey'
+  )
+  t.is(
+    shieldNote.tokenData.tokenType,
+    1,
+    'should convert ERC721 string to enum'
+  )
+})
+
+test('shield-note - fromCommitment ERC1155 token type conversion', async (t) => {
+  await initializeCryptographyLibs()
+
+  const commitment = {
+    hash: new Uint8Array(32),
+    treeNumber: 0,
+    treePosition: 0,
+    preimage: {
+      npk: hexToUint8Array('0x' + 'ab'.repeat(32)),
+      value: 100n,
+      token: {
+        tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+        tokenType: 'ERC1155',
+        tokenSubID: hexToUint8Array(
+          '0x0000000000000000000000000000000000000000000000000000000000000005'
+        ),
+      },
+    },
+    encryptedRandom: [hexToUint8Array('0x' + 'cd'.repeat(16))],
+  }
+
+  const shieldNote = ShieldNote.fromCommitment(commitment, 1n)
+
+  t.is(
+    shieldNote.tokenData.tokenType,
+    2,
+    'should convert ERC1155 string to enum'
+  )
+})
+
+test('shield-note - fromCommitment missing random throws', async (t) => {
+  await initializeCryptographyLibs()
+
+  const commitment = {
+    hash: new Uint8Array(32),
+    treeNumber: 0,
+    treePosition: 0,
+    preimage: {
+      npk: hexToUint8Array('0x' + 'ab'.repeat(32)),
+      value: 5000n,
+      token: {
+        tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+        tokenType: 'ERC20',
+        tokenSubID: hexToUint8Array(TEST_TOKEN_SUB_ID_ZERO),
+      },
+    },
+    encryptedRandom: [] as Uint8Array[],
+  }
+
+  t.exception(() => {
+    ShieldNote.fromCommitment(commitment, 1n)
+  }, 'should throw when random data is missing')
+})
+
+test('shield-note - fromCommitment missing masterPublicKey throws', async (t) => {
+  await initializeCryptographyLibs()
+
+  const commitment = {
+    hash: new Uint8Array(32),
+    treeNumber: 0,
+    treePosition: 0,
+    preimage: {
+      npk: hexToUint8Array('0x' + 'ab'.repeat(32)),
+      value: 5000n,
+      token: {
+        tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+        tokenType: 'ERC20',
+        tokenSubID: hexToUint8Array(TEST_TOKEN_SUB_ID_ZERO),
+      },
+    },
+    encryptedRandom: [hexToUint8Array('0x' + 'cd'.repeat(16))],
+  }
+
+  t.exception(() => {
+    // No masterPublicKey param and no shieldKey in commitment
+    ShieldNote.fromCommitment(commitment)
+  }, 'should throw when masterPublicKey is missing for GeneratedCommitment')
+})
+
+test('shield-note - fromCommitment invalid tokenType throws', async (t) => {
+  await initializeCryptographyLibs()
+
+  const commitment = {
+    hash: new Uint8Array(32),
+    treeNumber: 0,
+    treePosition: 0,
+    preimage: {
+      npk: hexToUint8Array('0x' + 'ab'.repeat(32)),
+      value: 5000n,
+      token: {
+        tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+        tokenType: 'INVALID',
+        tokenSubID: hexToUint8Array(TEST_TOKEN_SUB_ID_ZERO),
+      },
+    },
+    encryptedRandom: [hexToUint8Array('0x' + 'cd'.repeat(16))],
+  }
+
+  t.exception(() => {
+    ShieldNote.fromCommitment(commitment, 1n)
+  }, 'should throw for invalid token type string')
+})
+
+test('transact-note - create TransactNote', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData
+  )
+
+  t.ok(
+    transactNote instanceof TransactNote,
+    'should create TransactNote instance'
+  )
+  t.is(transactNote.value, TEST_VALUE, 'should set value correctly')
+  t.is(transactNote.hash, hash, 'should set hash correctly')
+  t.ok(transactNote.receiverAddressData, 'should set receiverAddressData')
+  t.is(
+    transactNote.tokenHash,
+    computeTokenHash(ERC20_TOKEN_DATA),
+    'should compute token hash'
+  )
+})
+
+test('transact-note - serialize and deserialize', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData
+  )
+  const serialized = transactNote.serialize()
+
+  t.ok(serialized instanceof Uint8Array, 'should serialize to Uint8Array')
+
+  const deserialized = TransactNote.deserialize(serialized)
+
+  t.ok(
+    deserialized instanceof TransactNote,
+    'should deserialize to TransactNote'
+  )
+  t.is(deserialized.value, TEST_VALUE, 'should preserve value')
+  t.is(deserialized.hash, hash, 'should preserve hash')
+  t.is(deserialized.random, TEST_RANDOM, 'should preserve random')
+  t.is(deserialized.notePublicKey, TEST_NPK, 'should preserve notePublicKey')
+  t.is(
+    deserialized.tokenData.tokenType,
+    ERC20_TOKEN_DATA.tokenType,
+    'should preserve tokenType'
+  )
+  t.is(
+    deserialized.receiverAddressData.masterPublicKey,
+    receiverAddressData.masterPublicKey,
+    'should preserve receiver masterPublicKey'
+  )
+})
+
+test('transact-note - serialize and deserialize with all optional fields', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32).fill(0xaa),
+  }
+  const senderAddressData = {
+    masterPublicKey: BigInt('987654321098765432109876543210'),
+    viewingPublicKey: new Uint8Array(32).fill(0xbb),
+  }
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData,
+    senderAddressData,
+    1, // outputType (BroadcasterFee)
+    'test-wallet', // walletSource
+    'aabbccdd11223344aabbccdd11223344', // senderRandom
+    'Hello memo', // memoText
+    '1000', // shieldFee
+    42 // blockNumber
+  )
+
+  const serialized = transactNote.serialize()
+  const deserialized = TransactNote.deserialize(serialized)
+
+  t.is(deserialized.value, TEST_VALUE, 'should preserve value')
+  t.is(deserialized.hash, hash, 'should preserve hash')
+  t.is(deserialized.random, TEST_RANDOM, 'should preserve random')
+  t.is(
+    deserialized.receiverAddressData.masterPublicKey,
+    receiverAddressData.masterPublicKey,
+    'should preserve receiver masterPublicKey'
+  )
+  t.ok(deserialized.senderAddressData, 'should preserve senderAddressData')
+  t.is(
+    deserialized.senderAddressData!.masterPublicKey,
+    senderAddressData.masterPublicKey,
+    'should preserve sender masterPublicKey'
+  )
+  t.is(deserialized.outputType, 1, 'should preserve outputType')
+  t.is(
+    deserialized.walletSource,
+    'test-wallet',
+    'should preserve walletSource'
+  )
+  t.is(
+    deserialized.senderRandom,
+    'aabbccdd11223344aabbccdd11223344',
+    'should preserve senderRandom'
+  )
+  t.is(deserialized.memoText, 'Hello memo', 'should preserve memoText')
+  t.is(deserialized.shieldFee, '1000', 'should preserve shieldFee')
+  t.is(deserialized.blockNumber, 42, 'should preserve blockNumber')
+})
+
+test('transact-note - serialize and deserialize with no senderAddressData', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData
+  )
+  const serialized = transactNote.serialize()
+  const deserialized = TransactNote.deserialize(serialized)
+
+  t.is(
+    deserialized.senderAddressData,
+    undefined,
+    'senderAddressData should be undefined when not set'
+  )
+})
+
+test('transact-note - with memo text survives serialization', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+  const memoText = 'Test memo with special chars: !@#$%'
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    memoText
+  )
+
+  const serialized = transactNote.serialize()
+  const deserialized = TransactNote.deserialize(serialized)
+
+  t.is(
+    deserialized.memoText,
+    memoText,
+    'memo text should survive serialization roundtrip'
+  )
+})
+
+test('transact-note - getTokenHash matches computeTokenHash', async (t) => {
+  await initializeCryptographyLibs()
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData
+  )
+
+  t.is(
+    transactNote.getTokenHash(),
+    computeTokenHash(ERC20_TOKEN_DATA),
+    'getTokenHash should match computeTokenHash'
+  )
+})
+
+test('transact-note - fromCommitment', async (t) => {
+  await initializeCryptographyLibs()
+
+  const commitment = {
+    hash: new Uint8Array(32),
+    ciphertext: {
+      iv: new Uint8Array(16),
+      tag: new Uint8Array(16),
+      data: [] as Uint8Array[],
+    },
+    blindedSenderViewingKey: new Uint8Array(32),
+    blindedReceiverViewingKey: new Uint8Array(32),
+    annotationData: new Uint8Array(0),
+    memo: [],
+    treeNumber: 0,
+    treePosition: 0,
+  }
+
+  const random = TEST_RANDOM
+  const npk = TEST_NPK
+  const value = TEST_VALUE
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+
+  const transactNote = TransactNote.fromCommitment(
+    commitment,
+    random,
+    npk,
+    value,
+    ERC20_TOKEN_DATA,
+    receiverAddressData
+  )
+
+  t.ok(
+    transactNote instanceof TransactNote,
+    'should create TransactNote from commitment'
+  )
+  t.is(transactNote.value, TEST_VALUE, 'should set value')
+  t.is(transactNote.random, TEST_RANDOM, 'should set random')
+  t.is(transactNote.notePublicKey, TEST_NPK, 'should set npk')
+  // The hash should be computed via getNoteHash
+  t.is(typeof transactNote.hash, 'bigint', 'should compute hash as bigint')
+  t.ok(transactNote.hash > 0n, 'hash should be positive')
+})
+
+test('transact-note - fromCommitment with senderAddressData', async (t) => {
+  await initializeCryptographyLibs()
+
+  const commitment = {
+    hash: new Uint8Array(32),
+    ciphertext: {
+      iv: new Uint8Array(16),
+      tag: new Uint8Array(16),
+      data: [] as Uint8Array[],
+    },
+    blindedSenderViewingKey: new Uint8Array(32),
+    blindedReceiverViewingKey: new Uint8Array(32),
+    annotationData: new Uint8Array(0),
+    memo: [],
+    treeNumber: 0,
+    treePosition: 0,
+  }
+
+  const receiverAddressData = {
+    masterPublicKey: BigInt('111'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+  const senderAddressData = {
+    masterPublicKey: BigInt('222'),
+    viewingPublicKey: new Uint8Array(32),
+  }
+
+  const transactNote = TransactNote.fromCommitment(
+    commitment,
+    TEST_RANDOM,
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    receiverAddressData,
+    senderAddressData
+  )
+
+  t.ok(transactNote.senderAddressData, 'should set senderAddressData')
+  t.is(
+    transactNote.senderAddressData!.masterPublicKey,
+    BigInt('222'),
+    'should preserve sender masterPublicKey'
+  )
+})
+
+test('transact-note - isLegacyTransactNote', (t) => {
+  t.is(
+    isLegacyTransactNote({ encryptedRandom: ['abc', 'def'] }),
+    true,
+    'should detect legacy format with encryptedRandom'
+  )
+
+  t.is(
+    isLegacyTransactNote({ random: 'abc123' }),
+    false,
+    'should detect modern format without encryptedRandom'
+  )
+
+  t.is(isLegacyTransactNote({}), false, 'should return false for empty object')
+})
+
+test('transact-note - ciphertextToEncryptedRandomData', (t) => {
+  const ciphertext = {
+    iv: 'aabbccdd11223344',
+    tag: 'eeff00112233aabb',
+    data: ['deadbeef12345678'],
+  }
+
+  const result = ciphertextToEncryptedRandomData(ciphertext)
+
+  t.is(
+    result[0],
+    'aabbccdd11223344eeff00112233aabb',
+    'ivTag should be iv + tag concatenated'
+  )
+  t.is(result[1], 'deadbeef12345678', 'data should be first element')
+})
+
+test('transact-note - ciphertextToEncryptedRandomData empty data', (t) => {
+  const ciphertext = {
+    iv: 'aabbccdd11223344',
+    tag: 'eeff00112233aabb',
+    data: [] as string[],
+  }
+
+  const result = ciphertextToEncryptedRandomData(ciphertext)
+
+  t.is(
+    result[0],
+    'aabbccdd11223344eeff00112233aabb',
+    'ivTag should be iv + tag'
+  )
+  t.is(result[1], '', 'data should be empty string when no data')
+})
+
+test('transact-note - encryptedDataToCiphertext', (t) => {
+  // ivTag is 32 chars, so slice(0,32) gets full ivTag as iv, slice(32) gets empty tag
+  const encryptedData: [string, string] = [
+    'aabbccdd11223344eeff00112233aabb',
+    'deadbeef12345678',
+  ]
+
+  const result = encryptedDataToCiphertext(encryptedData)
+
+  // With 32-char ivTag: iv = slice(0,32), tag = slice(32) = ''
+  t.is(
+    result.iv,
+    'aabbccdd11223344eeff00112233aabb',
+    'iv should be first 32 chars of ivTag'
+  )
+  t.is(result.tag, '', 'tag should be remaining chars of ivTag')
+  t.is(result.data[0], 'deadbeef12345678', 'data should be preserved')
+})
+
+test('transact-note - ciphertextToEncryptedRandomData / encryptedDataToCiphertext roundtrip', (t) => {
+  const originalCiphertext = {
+    iv: 'aabbccdd11223344aabbccdd11223344',
+    tag: 'eeff00112233aabbeeff00112233aabb',
+    data: ['deadbeef12345678deadbeef12345678'],
+  }
+
+  const encrypted = ciphertextToEncryptedRandomData(originalCiphertext)
+  const restored = encryptedDataToCiphertext(encrypted)
+
+  t.is(restored.iv, originalCiphertext.iv, 'iv should roundtrip')
+  t.is(restored.tag, originalCiphertext.tag, 'tag should roundtrip')
+  t.is(restored.data[0], originalCiphertext.data[0], 'data should roundtrip')
+})
+
+test('transact-note - serializeLegacy and deserializeLegacy roundtrip', async (t) => {
+  await initializeCryptographyLibs()
+
+  // Generate real key pairs for encryption/decryption
+  const senderPrivateKey = randomBytes(32)
+  const senderPublicKey = getPublicViewingKey(senderPrivateKey)
+  const receiverPrivateKey = randomBytes(32)
+  const receiverPublicKey = getPublicViewingKey(receiverPrivateKey)
+
+  const hash = BigInt('99999999999999999999')
+  const receiverAddressData = {
+    masterPublicKey: BigInt('123456789012345678901234567890'),
+    viewingPublicKey: receiverPublicKey,
+  }
+
+  const transactNote = new TransactNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    hash,
+    receiverAddressData,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    'legacy memo',
+    undefined,
+    100
+  )
+
+  // Serialize with sender's private key and receiver's public key
+  const serialized = await transactNote.serializeLegacy(
+    senderPrivateKey,
+    receiverPublicKey
+  )
+  t.ok(
+    serialized instanceof Uint8Array,
+    'serializeLegacy should return Uint8Array'
+  )
+
+  // Deserialize with receiver's private key and sender's public key
+  const deserialized = await TransactNote.deserializeLegacy(
+    serialized,
+    receiverPrivateKey,
+    senderPublicKey
+  )
+
+  t.ok(
+    deserialized instanceof TransactNote,
+    'should deserialize to TransactNote'
+  )
+  t.is(deserialized.value, TEST_VALUE, 'should preserve value')
+  // deserializeLegacy returns random with 0x prefix via uint8ArrayToHex
+  t.is(
+    deserialized.random,
+    '0x' + TEST_RANDOM,
+    'should preserve random through encryption'
+  )
+  t.is(deserialized.notePublicKey, TEST_NPK, 'should preserve notePublicKey')
+  t.is(deserialized.memoText, 'legacy memo', 'should preserve memoText')
+  t.is(deserialized.blockNumber, 100, 'should preserve blockNumber')
+})
+
+test('unshield-note - create UnshieldNote', async (t) => {
+  await initializeCryptographyLibs()
+
+  const toAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+  const hash = BigInt('99999999999999999999')
+
+  const unshieldNote = new UnshieldNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    toAddress,
+    hash,
+    false
+  )
+
+  t.ok(
+    unshieldNote instanceof UnshieldNote,
+    'should create UnshieldNote instance'
+  )
+  t.is(unshieldNote.value, TEST_VALUE, 'should set value correctly')
+  t.is(unshieldNote.toAddress, toAddress, 'should set toAddress correctly')
+  t.is(unshieldNote.hash, hash, 'should set hash correctly')
+  t.is(unshieldNote.allowOverride, false, 'should set allowOverride correctly')
+})
+
+test('unshield-note - serialize and deserialize', async (t) => {
+  await initializeCryptographyLibs()
+
+  const toAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+  const hash = BigInt('99999999999999999999')
+
+  const unshieldNote = new UnshieldNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    toAddress,
+    hash,
+    true
+  )
+  const serialized = unshieldNote.serialize()
+
+  t.ok(serialized instanceof Uint8Array, 'should serialize to Uint8Array')
+
+  const deserialized = UnshieldNote.deserialize(serialized)
+
+  t.ok(
+    deserialized instanceof UnshieldNote,
+    'should deserialize to UnshieldNote'
+  )
+  t.is(deserialized.value, TEST_VALUE, 'should preserve value')
+  t.is(deserialized.toAddress, toAddress, 'should preserve toAddress')
+  t.is(deserialized.hash, hash, 'should preserve hash')
+  t.is(deserialized.allowOverride, true, 'should preserve allowOverride')
+  t.is(deserialized.random, TEST_RANDOM, 'should preserve random')
+  t.is(deserialized.notePublicKey, TEST_NPK, 'should preserve notePublicKey')
+})
+
+test('unshield-note - getTokenHash matches computeTokenHash', async (t) => {
+  await initializeCryptographyLibs()
+
+  const toAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+  const hash = BigInt('99999999999999999999')
+
+  const unshieldNote = new UnshieldNote(
+    TEST_NPK,
+    TEST_VALUE,
+    ERC20_TOKEN_DATA,
+    TEST_RANDOM,
+    toAddress,
+    hash,
+    false
+  )
+
+  t.is(
+    unshieldNote.getTokenHash(),
+    computeTokenHash(ERC20_TOKEN_DATA),
+    'getTokenHash should match computeTokenHash'
+  )
+})
+
+test('unshield-note - fromUnshield ERC20', async (t) => {
+  await initializeCryptographyLibs()
+
+  const unshieldData = {
+    to: hexToUint8Array('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'),
+    token: {
+      tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+      tokenType: 'ERC20',
+      tokenSubID: hexToUint8Array(TEST_TOKEN_SUB_ID_ZERO),
+    },
+    amount: TEST_VALUE,
+    fee: 100n,
+  }
+
+  const unshieldNote = UnshieldNote.fromUnshield(unshieldData, TEST_RANDOM)
+
+  t.ok(
+    unshieldNote instanceof UnshieldNote,
+    'should create UnshieldNote from unshield data'
+  )
+  t.is(unshieldNote.value, TEST_VALUE, 'should set value from amount')
+  t.is(
+    unshieldNote.tokenData.tokenType,
+    0,
+    'should convert ERC20 string to enum'
+  )
+  t.is(
+    unshieldNote.allowOverride,
+    false,
+    'should default allowOverride to false'
+  )
+  t.ok(unshieldNote.hash > 0n, 'should compute hash')
+})
+
+test('unshield-note - fromUnshield ERC721', async (t) => {
+  await initializeCryptographyLibs()
+
+  const unshieldData = {
+    to: hexToUint8Array('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'),
+    token: {
+      tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+      tokenType: 'ERC721',
+      tokenSubID: hexToUint8Array(
+        '0x0000000000000000000000000000000000000000000000000000000000000001'
+      ),
+    },
+    amount: 1n,
+    fee: 0n,
+  }
+
+  const unshieldNote = UnshieldNote.fromUnshield(unshieldData, TEST_RANDOM)
+
+  t.is(
+    unshieldNote.tokenData.tokenType,
+    1,
+    'should convert ERC721 string to enum'
+  )
+})
+
+test('unshield-note - fromUnshield ERC1155', async (t) => {
+  await initializeCryptographyLibs()
+
+  const unshieldData = {
+    to: hexToUint8Array('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'),
+    token: {
+      tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+      tokenType: 'ERC1155',
+      tokenSubID: hexToUint8Array(
+        '0x0000000000000000000000000000000000000000000000000000000000000005'
+      ),
+    },
+    amount: 50n,
+    fee: 5n,
+  }
+
+  const unshieldNote = UnshieldNote.fromUnshield(unshieldData, TEST_RANDOM)
+
+  t.is(
+    unshieldNote.tokenData.tokenType,
+    2,
+    'should convert ERC1155 string to enum'
+  )
+})
+
+test('unshield-note - fromUnshield invalid tokenType throws', async (t) => {
+  await initializeCryptographyLibs()
+
+  const unshieldData = {
+    to: hexToUint8Array('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'),
+    token: {
+      tokenAddress: hexToUint8Array(TEST_TOKEN_ADDRESS),
+      tokenType: 'INVALID',
+      tokenSubID: hexToUint8Array(TEST_TOKEN_SUB_ID_ZERO),
+    },
+    amount: TEST_VALUE,
+    fee: 0n,
+  }
+
+  t.exception(() => {
+    UnshieldNote.fromUnshield(unshieldData, TEST_RANDOM)
+  }, 'should throw for invalid token type string')
+})
+
+test('decrypt-commitment - decryptCommitment with invalid key returns null', async (t) => {
+  await initializeCryptographyLibs()
+
+  const ciphertext = {
+    iv: randomBytes(16),
+    tag: randomBytes(16),
+    data: [randomBytes(100)],
+  }
+  const blindedViewingKey = randomBytes(32)
+  const viewingPrivateKey = randomBytes(32)
+
+  const result = await decryptCommitment(
+    ciphertext,
+    blindedViewingKey,
+    viewingPrivateKey
+  )
+
+  t.is(result, null, 'should return null for invalid decryption')
+})
+
+test('decrypt-commitment - decryptCommitmentAsReceiverOrSender with invalid keys returns null', async (t) => {
+  await initializeCryptographyLibs()
+
+  const ciphertext = {
+    iv: randomBytes(16),
+    tag: randomBytes(16),
+    data: [randomBytes(100)],
+  }
+  const blindedReceiverKey = randomBytes(32)
+  const blindedSenderKey = randomBytes(32)
+  const viewingPrivateKey = randomBytes(32)
+
+  const result = await decryptCommitmentAsReceiverOrSender(
+    ciphertext,
+    blindedReceiverKey,
+    blindedSenderKey,
+    viewingPrivateKey
+  )
+
+  t.is(result, null, 'should return null when unable to decrypt')
+})
+
+test('decrypt-commitment - decryptCommitment successful roundtrip', async (t) => {
+  await initializeCryptographyLibs()
+
+  // Generate real key pairs
+  const viewingPrivateKey = randomBytes(32)
+  const viewingPublicKey = getPublicViewingKey(viewingPrivateKey)
+
+  // Create the blinded key using a known random
+  const sharedRandom = randomBytes(32)
+  const senderRandom = new Uint8Array(32) // zero sender random for simplicity
+
+  const senderPrivateKey = randomBytes(32)
+  const senderPublicKey = getPublicViewingKey(senderPrivateKey)
+
+  const { blindedReceiverViewingKey } = getNoteBlindingKeys(
+    senderPublicKey,
+    viewingPublicKey,
+    sharedRandom,
+    senderRandom
+  )
+
+  // Build plaintext data matching the format expected by decryptCommitment:
+  // random (16) + npk (32) + value (32) + tokenAddress (20) + tokenType (1) + tokenSubID (32) = 133 bytes
+  const noteRandom = randomBytes(16)
+  const npk = randomBytes(32)
+  const value = bigintToUint8Array(TEST_VALUE, 32)
+  const tokenAddress = hexToUint8Array(TEST_TOKEN_ADDRESS)
+  const tokenType = new Uint8Array([0]) // ERC20
+  const tokenSubID = new Uint8Array(32) // zero
+
+  const plaintext = new Uint8Array(133)
+  plaintext.set(noteRandom, 0)
+  plaintext.set(npk, 16)
+  plaintext.set(value, 48)
+  plaintext.set(tokenAddress, 80)
+  plaintext.set(tokenType, 100)
+  plaintext.set(tokenSubID, 101)
+
+  // Encrypt using the shared key derived from viewingPrivateKey + blindedReceiverViewingKey
+  const sharedKey = await getSharedSymmetricKey(
+    viewingPrivateKey,
+    blindedReceiverViewingKey
+  )
+  t.ok(sharedKey, 'should generate shared key')
+
+  const ciphertext = AES.encryptGCM([plaintext], sharedKey!)
+
+  // Now decrypt using the same viewingPrivateKey + blindedReceiverViewingKey
+  const result = await decryptCommitment(
+    ciphertext,
+    blindedReceiverViewingKey,
+    viewingPrivateKey
+  )
+
+  t.ok(result !== null, 'should successfully decrypt')
+  t.is(result!.random, uint8ArrayToHex(noteRandom), 'should recover random')
+  t.is(result!.npk, uint8ArrayToHex(npk), 'should recover npk')
+  t.is(result!.value, TEST_VALUE, 'should recover value')
+  t.is(result!.tokenData.tokenType, 0, 'should recover tokenType')
+  t.is(
+    result!.tokenData.tokenAddress,
+    uint8ArrayToHex(tokenAddress),
+    'should recover tokenAddress'
+  )
+})
+
+test('decrypt-commitment - decryptCommitmentAsReceiverOrSender identifies receiver', async (t) => {
+  await initializeCryptographyLibs()
+
+  const viewingPrivateKey = randomBytes(32)
+  const viewingPublicKey = getPublicViewingKey(viewingPrivateKey)
+
+  const sharedRandom = randomBytes(32)
+  const senderRandom = new Uint8Array(32)
+
+  const senderPrivateKey = randomBytes(32)
+  const senderPublicKey = getPublicViewingKey(senderPrivateKey)
+
+  const { blindedReceiverViewingKey } = getNoteBlindingKeys(
+    senderPublicKey,
+    viewingPublicKey,
+    sharedRandom,
+    senderRandom
+  )
+
+  // Build plaintext
+  const plaintext = new Uint8Array(133)
+  plaintext.set(randomBytes(16), 0) // random
+  plaintext.set(randomBytes(32), 16) // npk
+  plaintext.set(bigintToUint8Array(TEST_VALUE, 32), 48) // value
+  plaintext.set(hexToUint8Array(TEST_TOKEN_ADDRESS), 80) // tokenAddress
+  plaintext.set(new Uint8Array([0]), 100) // tokenType
+  plaintext.set(new Uint8Array(32), 101) // tokenSubID
+
+  // Encrypt with receiver's shared key
+  const sharedKey = await getSharedSymmetricKey(
+    viewingPrivateKey,
+    blindedReceiverViewingKey
+  )
+  const ciphertext = AES.encryptGCM([plaintext], sharedKey!)
+
+  // Use a different key for the sender blinded key so only receiver path works
+  const fakeBlindedSenderKey = getPublicViewingKey(randomBytes(32))
+
+  const result = await decryptCommitmentAsReceiverOrSender(
+    ciphertext,
+    blindedReceiverViewingKey,
+    fakeBlindedSenderKey,
+    viewingPrivateKey
+  )
+
+  t.ok(result !== null, 'should successfully decrypt')
+  t.is(result!.isReceiver, true, 'should identify as receiver')
+  t.is(result!.data.value, TEST_VALUE, 'should recover value')
+})

--- a/test/seed.test.ts
+++ b/test/seed.test.ts
@@ -1,0 +1,177 @@
+import { test } from 'brittle'
+
+import { childKeyDerivationHardened, getMasterKeyFromSeed, getPathSegments } from '../src/seed/bip32'
+import { Mnemonic } from '../src/seed/bip39'
+
+test('bip39 - Mnemonic.generate', (t) => {
+  const mnemonic128 = Mnemonic.generate(128)
+  t.is(typeof mnemonic128, 'string', 'should return a string')
+  t.is(mnemonic128.split(' ').length, 12, 'should generate 12 words for 128-bit entropy')
+
+  const mnemonic192 = Mnemonic.generate(192)
+  t.is(mnemonic192.split(' ').length, 18, 'should generate 18 words for 192-bit entropy')
+
+  const mnemonic256 = Mnemonic.generate(256)
+  t.is(mnemonic256.split(' ').length, 24, 'should generate 24 words for 256-bit entropy')
+})
+
+test('bip39 - Mnemonic.validate', (t) => {
+  const validMnemonic = 'test test test test test test test test test test test junk'
+  t.ok(Mnemonic.validate(validMnemonic), 'should validate correct mnemonic')
+
+  const invalidMnemonic = 'invalid mnemonic phrase that should not work'
+  t.absent(Mnemonic.validate(invalidMnemonic), 'should not validate incorrect mnemonic')
+
+  const emptyMnemonic = ''
+  t.absent(Mnemonic.validate(emptyMnemonic), 'should not validate empty string')
+})
+
+test('bip39 - Mnemonic.toSeed', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+
+  t.ok(seed instanceof Uint8Array, 'should return Uint8Array')
+  t.is(seed.length, 64, 'should return 64 bytes')
+
+  // Test with password
+  const seedWithPassword = Mnemonic.toSeed(mnemonic, 'password123')
+  t.ok(seedWithPassword instanceof Uint8Array, 'should return Uint8Array with password')
+  t.not(seed, seedWithPassword, 'should generate different seed with password')
+})
+
+test('bip39 - Mnemonic.toSeed deterministic', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed1 = Mnemonic.toSeed(mnemonic)
+  const seed2 = Mnemonic.toSeed(mnemonic)
+
+  t.alike(seed1, seed2, 'should generate same seed from same mnemonic')
+})
+
+test('bip39 - Mnemonic.toEntropy and fromEntropy', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const entropy = Mnemonic.toEntropy(mnemonic)
+
+  t.ok(entropy instanceof Uint8Array, 'should return Uint8Array')
+  t.ok(entropy.length >= 16, 'entropy should be at least 16 bytes')
+
+  const recoveredMnemonic = Mnemonic.fromEntropy(entropy)
+  t.is(recoveredMnemonic, mnemonic, 'should recover same mnemonic from entropy')
+})
+
+test('bip39 - Mnemonic.to0xPrivateKey', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const privateKey = Mnemonic.to0xPrivateKey(mnemonic)
+
+  t.ok(privateKey instanceof Uint8Array, 'should return Uint8Array')
+  t.is(privateKey.length, 32, 'should return 32 bytes')
+})
+
+test('bip39 - Mnemonic.to0xPrivateKey with derivation index', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const privateKey0 = Mnemonic.to0xPrivateKey(mnemonic, 0)
+  const privateKey1 = Mnemonic.to0xPrivateKey(mnemonic, 1)
+
+  t.not(privateKey0, privateKey1, 'should generate different keys for different indices')
+})
+
+test('bip39 - Mnemonic.to0xPrivateKey deterministic', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const privateKey1 = Mnemonic.to0xPrivateKey(mnemonic, 0)
+  const privateKey2 = Mnemonic.to0xPrivateKey(mnemonic, 0)
+
+  t.alike(privateKey1, privateKey2, 'should generate same key from same mnemonic and index')
+})
+
+test('bip32 - getPathSegments', (t) => {
+  const path1 = "m/44'/0'/0'"
+  const segments1 = getPathSegments(path1)
+  t.alike(segments1, [44, 0, 0], 'should parse simple path correctly')
+
+  const path2 = "m/44'/1984'/0'/0'/5'"
+  const segments2 = getPathSegments(path2)
+  t.alike(segments2, [44, 1984, 0, 0, 5], 'should parse complex path correctly')
+})
+
+test('bip32 - getPathSegments invalid path', (t) => {
+  t.exception(() => {
+    getPathSegments('invalid/path')
+  }, 'should throw error for invalid path')
+
+  t.exception(() => {
+    getPathSegments('m/44/0/0')
+  }, 'should throw error for non-hardened path')
+})
+
+test('bip32 - getMasterKeyFromSeed', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+  const masterKey = getMasterKeyFromSeed(seed)
+
+  t.ok(masterKey.chainKey instanceof Uint8Array, 'should return chainKey as Uint8Array')
+  t.ok(masterKey.chainCode instanceof Uint8Array, 'should return chainCode as Uint8Array')
+  t.is(masterKey.chainKey.length, 32, 'chainKey should be 32 bytes')
+  t.is(masterKey.chainCode.length, 32, 'chainCode should be 32 bytes')
+})
+
+test('bip32 - getMasterKeyFromSeed deterministic', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+  const masterKey1 = getMasterKeyFromSeed(seed)
+  const masterKey2 = getMasterKeyFromSeed(seed)
+
+  t.alike(masterKey1.chainKey, masterKey2.chainKey, 'should generate same chainKey')
+  t.alike(masterKey1.chainCode, masterKey2.chainCode, 'should generate same chainCode')
+})
+
+test('bip32 - childKeyDerivationHardened', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+  const masterKey = getMasterKeyFromSeed(seed)
+
+  const childKey = childKeyDerivationHardened(masterKey, 0)
+
+  t.ok(childKey.chainKey instanceof Uint8Array, 'should return chainKey as Uint8Array')
+  t.ok(childKey.chainCode instanceof Uint8Array, 'should return chainCode as Uint8Array')
+  t.is(childKey.chainKey.length, 32, 'chainKey should be 32 bytes')
+  t.is(childKey.chainCode.length, 32, 'chainCode should be 32 bytes')
+  t.not(childKey.chainKey, masterKey.chainKey, 'child key should differ from parent')
+})
+
+test('bip32 - childKeyDerivationHardened different indices', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+  const masterKey = getMasterKeyFromSeed(seed)
+
+  const childKey0 = childKeyDerivationHardened(masterKey, 0)
+  const childKey1 = childKeyDerivationHardened(masterKey, 1)
+
+  t.not(childKey0.chainKey, childKey1.chainKey, 'should generate different keys for different indices')
+})
+
+test('bip32 - childKeyDerivationHardened deterministic', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+  const masterKey = getMasterKeyFromSeed(seed)
+
+  const childKey1 = childKeyDerivationHardened(masterKey, 0)
+  const childKey2 = childKeyDerivationHardened(masterKey, 0)
+
+  t.alike(childKey1.chainKey, childKey2.chainKey, 'should generate same key for same index')
+  t.alike(childKey1.chainCode, childKey2.chainCode, 'should generate same chainCode for same index')
+})
+
+test('bip32 - full derivation path', (t) => {
+  const mnemonic = 'test test test test test test test test test test test junk'
+  const seed = Mnemonic.toSeed(mnemonic)
+  let currentKey = getMasterKeyFromSeed(seed)
+
+  const path = "m/44'/1984'/0'/0'/5'"
+  const segments = getPathSegments(path)
+
+  for (const segment of segments) {
+    currentKey = childKeyDerivationHardened(currentKey, segment)
+  }
+
+  t.ok(currentKey.chainKey instanceof Uint8Array, 'should derive key through full path')
+  t.is(currentKey.chainKey.length, 32, 'derived key should be 32 bytes')
+})

--- a/test/wallet-node.test.ts
+++ b/test/wallet-node.test.ts
@@ -1,0 +1,247 @@
+import { stringify } from '@railgun-reloaded/0zk-addresses'
+import { test } from 'brittle'
+
+import { initializeCryptographyLibs } from '../src/keys'
+import { RailgunWallet } from '../src/wallet-node/railgun'
+import { WalletNode } from '../src/wallet-node/wallet-node'
+
+const TEST_MNEMONIC = 'test test test test test test test test test test test junk'
+const TEST_MNEMONIC_2 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+test('wallet-node - WalletNode.fromMnemonic', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+
+  t.ok(walletNode instanceof WalletNode, 'should return WalletNode instance')
+  t.ok(typeof walletNode.derive === 'function', 'should have derive method')
+  t.ok(typeof walletNode.getSpendingKeyPair === 'function', 'should have getSpendingKeyPair method')
+})
+
+test('wallet-node - WalletNode.derive', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const derivedNode = walletNode.derive("m/44'/1984'/0'/0'/0'")
+
+  t.ok(derivedNode instanceof WalletNode, 'should return WalletNode instance')
+  t.not(derivedNode, walletNode, 'should return new instance')
+})
+
+test('wallet-node - WalletNode.derive multiple paths', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const derived1 = walletNode.derive("m/44'/1984'/0'/0'/0'")
+  const derived2 = walletNode.derive("m/44'/1984'/0'/0'/1'")
+
+  const key1 = derived1.getSpendingKeyPair()
+  const key2 = derived2.getSpendingKeyPair()
+
+  t.not(key1.privateKey, key2.privateKey, 'should generate different keys for different paths')
+})
+
+test('wallet-node - WalletNode.getSpendingKeyPair', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const keyPair = walletNode.getSpendingKeyPair()
+
+  t.ok(keyPair.privateKey instanceof Uint8Array, 'should return privateKey as Uint8Array')
+  t.ok(Array.isArray(keyPair.pubkey), 'should return pubkey as array')
+  t.is(keyPair.pubkey.length, 2, 'pubkey should have 2 elements')
+  t.is(keyPair.privateKey.length, 32, 'privateKey should be 32 bytes')
+})
+
+test('wallet-node - WalletNode.getViewingKeyPair', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const keyPair = walletNode.getViewingKeyPair()
+
+  t.ok(keyPair.privateKey instanceof Uint8Array, 'should return privateKey as Uint8Array')
+  t.ok(keyPair.pubkey instanceof Uint8Array, 'should return pubkey as Uint8Array')
+  t.is(keyPair.privateKey.length, 32, 'privateKey should be 32 bytes')
+  t.is(keyPair.pubkey.length, 32, 'pubkey should be 32 bytes')
+})
+
+test('wallet-node - WalletNode.getNullifyingKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const nullifyingKey = walletNode.getNullifyingKey()
+
+  t.ok(nullifyingKey instanceof Uint8Array, 'should return Uint8Array')
+  t.ok(nullifyingKey.length > 0, 'should return non-empty array')
+})
+
+test('wallet-node - WalletNode.getMasterPublicKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const spendingKeyPair = walletNode.getSpendingKeyPair()
+  const nullifyingKey = walletNode.getNullifyingKey()
+
+  const masterPublicKey = WalletNode.getMasterPublicKey(spendingKeyPair.pubkey, nullifyingKey)
+
+  t.ok(masterPublicKey instanceof Uint8Array, 'should return Uint8Array')
+  t.ok(masterPublicKey.length > 0, 'should return non-empty array')
+})
+
+test('wallet-node - WalletNode deterministic', async (t) => {
+  await initializeCryptographyLibs()
+
+  const walletNode1 = WalletNode.fromMnemonic(TEST_MNEMONIC)
+  const walletNode2 = WalletNode.fromMnemonic(TEST_MNEMONIC)
+
+  const key1 = walletNode1.getSpendingKeyPair()
+  const key2 = walletNode2.getSpendingKeyPair()
+
+  t.alike(key1.privateKey, key2.privateKey, 'should generate same keys from same mnemonic')
+})
+
+test('railgun-wallet - RailgunWallet initialization', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+
+  t.ok(wallet instanceof RailgunWallet, 'should create RailgunWallet instance')
+})
+
+test('railgun-wallet - RailgunWallet.getSpendingPrivateKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+  const privateKey = wallet.getSpendingPrivateKey()
+
+  t.ok(privateKey instanceof Uint8Array, 'should return Uint8Array')
+  t.is(privateKey.length, 32, 'should return 32 bytes')
+})
+
+test('railgun-wallet - RailgunWallet.getSpendingPublicKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+  const publicKey = wallet.getSpendingPublicKey()
+
+  t.ok(Array.isArray(publicKey), 'should return array')
+  t.is(publicKey.length, 2, 'should have 2 elements')
+})
+
+test('railgun-wallet - RailgunWallet.getMasterPublicKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+  const masterPublicKey = wallet.getMasterPublicKey()
+
+  t.ok(masterPublicKey instanceof Uint8Array, 'should return Uint8Array')
+  t.ok(masterPublicKey.length > 0, 'should return non-empty array')
+})
+
+test('railgun-wallet - RailgunWallet.getNullifyingKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+  const nullifyingKey = wallet.getNullifyingKey()
+
+  t.ok(nullifyingKey instanceof Uint8Array, 'should return Uint8Array')
+  t.ok(nullifyingKey.length > 0, 'should return non-empty array')
+})
+
+test('railgun-wallet - RailgunWallet.getViewingPublicKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+  const viewingPublicKey = wallet.getViewingPublicKey()
+
+  t.ok(viewingPublicKey instanceof Uint8Array, 'should return Uint8Array')
+  t.is(viewingPublicKey.length, 32, 'should return 32 bytes')
+})
+
+test('railgun-wallet - RailgunWallet.getViewingPrivateKey', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+  const viewingPrivateKey = wallet.getViewingPrivateKey()
+
+  t.ok(viewingPrivateKey instanceof Uint8Array, 'should return Uint8Array')
+  t.is(viewingPrivateKey.length, 32, 'should return 32 bytes')
+})
+
+test('railgun-wallet - RailgunWallet with custom index', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet0 = new RailgunWallet(TEST_MNEMONIC, 0)
+  const wallet1 = new RailgunWallet(TEST_MNEMONIC, 1)
+
+  const key0 = wallet0.getSpendingPrivateKey()
+  const key1 = wallet1.getSpendingPrivateKey()
+
+  t.not(key0, key1, 'should generate different keys for different indices')
+})
+
+test('railgun-wallet - RailgunWallet deterministic', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet1 = new RailgunWallet(TEST_MNEMONIC, 0)
+  const wallet2 = new RailgunWallet(TEST_MNEMONIC, 0)
+
+  const key1 = wallet1.getSpendingPrivateKey()
+  const key2 = wallet2.getSpendingPrivateKey()
+
+  t.alike(key1, key2, 'should generate same keys from same mnemonic and index')
+})
+
+test('railgun-wallet - RailgunWallet generates expected address', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet = new RailgunWallet(TEST_MNEMONIC)
+
+  const expectedAddress = stringify({
+    masterPublicKey: new Uint8Array([
+      44, 89, 205, 71, 51, 249, 17, 186,
+      116, 13, 166, 143, 183, 186, 59, 135,
+      63, 33, 218, 236, 228, 227, 161, 5,
+      174, 241, 45, 100, 20, 229, 78, 191
+    ]),
+    viewingPublicKey: new Uint8Array([
+      119, 215, 170, 124, 91, 151, 128, 96,
+      190, 43, 167, 140, 188, 14, 249, 42,
+      79, 58, 163, 252, 41, 128, 62, 175,
+      71, 132, 124, 245, 16, 185, 134, 234
+    ])
+  })
+
+  const railgunAddress = stringify({
+    masterPublicKey: wallet.getMasterPublicKey(),
+    viewingPublicKey: wallet.getViewingPublicKey(),
+  })
+
+  t.is(expectedAddress, '0zk1qyk9nn28x0u3rwn5pknglda68wrn7gw6anjw8gg94mcj6eq5u48tlrv7j6fe3z53lama02nutwtcqc979wnce0qwly4y7w4rls5cq040g7z8eagshxrw5ajy990', 'expected address constant should be correct')
+  t.is(expectedAddress, railgunAddress, 'wallet should generate expected address')
+})
+
+test('railgun-wallet - RailgunWallet.getShieldPrivateKeySignatureMessage', (t) => {
+  const message = RailgunWallet.getShieldPrivateKeySignatureMessage()
+
+  t.is(message, 'RAILGUN_SHIELD', 'should return correct constant message')
+})
+
+test('railgun-wallet - Different mnemonics generate different wallets', async (t) => {
+  await initializeCryptographyLibs()
+
+  const wallet1 = new RailgunWallet(TEST_MNEMONIC, 0)
+  const wallet2 = new RailgunWallet(TEST_MNEMONIC_2, 0)
+
+  const address1 = stringify({
+    masterPublicKey: wallet1.getMasterPublicKey(),
+    viewingPublicKey: wallet1.getViewingPublicKey(),
+  })
+
+  const address2 = stringify({
+    masterPublicKey: wallet2.getMasterPublicKey(),
+    viewingPublicKey: wallet2.getViewingPublicKey(),
+  })
+
+  t.not(address1, address2, 'different mnemonics should generate different addresses')
+})


### PR DESCRIPTION
## Summary
- Add test coverage for derivation, hashing, keys, BIP32 seed, and wallet-node modules
- Add extensive notes system tests covering all note types, serialization, token utils, and commitment decryption (~1,500 lines)

## Changes
- `test/derive.test.ts` — derivation path tests
- `test/hash.test.ts` — hash utility tests
- `test/keys.test.ts` — key generation and crypto tests
- `test/seed.test.ts` — BIP32 seed derivation tests
- `test/wallet-node.test.ts` — wallet-node integration tests
- `test/notes.test.ts` — comprehensive notes system tests

## Stacked PR
This is **PR 4 of 4** in the note-types split:
1. #6 — Config/tooling
2. #7 — JSDoc improvements + hex conversion utilities
3. #8 — Note types, token utils, and note classes
4. **This PR** — Comprehensive test suite

**Base:** `pr/note-system` (PR #8)

## Test plan
- [ ] `npm test` passes all tests
- [ ] All note types have coverage
- [ ] All crypto utilities have coverage