### PR TITLE
fix: pad poseidon inputs, add computeNullifier and computeNotePublicKey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ node_modules
 setup
 immutable-tags.json
 protected-main.json
+
+# dev-container
+.devcontainer/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/railgun-reloaded/wallet-node#readme",
   "main": "src/index.js",
-  "types": "src/index.d.ts",
+  "types": "src/index.ts",
   "devDependencies": {
     "@types/brittle": "^3.5.0",
     "eslint": "^9.24.0",

--- a/src/notes/note.ts
+++ b/src/notes/note.ts
@@ -1,6 +1,6 @@
 import { poseidon } from '@railgun-reloaded/cryptography'
 
-import { bigintToUint8Array, hexlify } from '../encoding'
+import { bigintToUint8Array, hexlify, padUint8Array } from '../encoding'
 import { assertCryptoInitialized } from '../keys'
 
 import type { TokenData } from './definitions'
@@ -85,8 +85,21 @@ abstract class Note {
    */
   static getHash (npk: Uint8Array, tokenHash: Uint8Array, value: bigint): Uint8Array {
     assertCryptoInitialized()
-    const valueBytes = bigintToUint8Array(value, 16) // 128-bit value
-    return poseidon([npk, tokenHash, valueBytes])
+    const valueBytes = bigintToUint8Array(value, 32)
+    return poseidon([padUint8Array(npk, 32), padUint8Array(tokenHash, 32), valueBytes])
+  }
+
+  /**
+   * Computes the note public key (NPK) from a master public key and random value.
+   * NPK = poseidon(masterPublicKey, random)
+   * @param masterPublicKey - The receiver's master public key as a Uint8Array
+   * @param random - The note random value as a Uint8Array (16 bytes)
+   * @returns The note public key as a Uint8Array
+   * @throws {Error} If initializeCryptographyLibs() has not been called.
+   */
+  static computeNotePublicKey (masterPublicKey: Uint8Array, random: Uint8Array): Uint8Array {
+    assertCryptoInitialized()
+    return poseidon([padUint8Array(masterPublicKey, 32), padUint8Array(random, 32)])
   }
 
   /**

--- a/src/notes/note.ts
+++ b/src/notes/note.ts
@@ -90,6 +90,19 @@ abstract class Note {
   }
 
   /**
+   * Computes the nullifier for a note at a given leaf index.
+   * The nullifier uniquely identifies a note when it is spent.
+   * @param nullifyingKey - The wallet's nullifying key as a Uint8Array
+   * @param leafIndex - The note's position in the merkle tree
+   * @returns The nullifier as a Uint8Array
+   * @throws {Error} If initializeCryptographyLibs() has not been called.
+   */
+  static computeNullifier (nullifyingKey: Uint8Array, leafIndex: bigint): Uint8Array {
+    assertCryptoInitialized()
+    return poseidon([nullifyingKey, bigintToUint8Array(leafIndex, 32)])
+  }
+
+  /**
    * Serializes the note to a Uint8Array.
    * Must be implemented by subclasses.
    * @returns The serialized note

--- a/test/note.test.ts
+++ b/test/note.test.ts
@@ -58,7 +58,7 @@ test('Note.getHash - known vector and properties', async (t) => {
   const hash1 = Note.getHash(npkBytes, tokenHashBytes, BigInt('1000000000000000000'))
   t.is(
     uint8ArrayToBigInt(hash1),
-    7822264150748016131168246751038092891550418438611309934403065338118898163274n,
+    383327982694222908883234614730482634434594360360520710439697655391370961429n,
     'should match known poseidon hash'
   )
 
@@ -94,6 +94,49 @@ test('Note.assertValidRandom - empty string', (t) => {
   t.exception(() => {
     Note.assertValidRandom('')
   }, 'should throw for empty string')
+})
+
+test('Note.computeNotePublicKey - known vector', (t) => {
+  const mpk = hexToUint8Array('0d40499ad038520838c733cf1d214c953bc02f5f836dcb5ab3d3b0b1df88b560')
+  const random = hexToUint8Array('aabbccdd11223344aabbccdd11223344')
+  const npk = Note.computeNotePublicKey(mpk, random)
+  t.is(
+    uint8ArrayToHex(npk),
+    '0x29ff6e77d641ba129aa692e36df05f05ae731a93c232f613e137e09058a79d1c',
+    'should match known poseidon(mpk, random)'
+  )
+})
+
+test('Note.computeNotePublicKey - 16-byte random is padded to 32 bytes', (t) => {
+  const mpk = hexToUint8Array('1234567890123456789012345678901234567890123456789012345678901234')
+  const random16 = hexToUint8Array('aabbccdd11223344aabbccdd11223344')
+  const random32 = hexToUint8Array('00000000000000000000000000000000aabbccdd11223344aabbccdd11223344')
+  const npk16 = Note.computeNotePublicKey(mpk, random16)
+  const npk32 = Note.computeNotePublicKey(mpk, random32)
+  t.alike(npk16, npk32, 'padded 16-byte random should equal explicit 32-byte zero-padded random')
+})
+
+test('Note.computeNotePublicKey - determinism', (t) => {
+  const mpk = hexToUint8Array('0d40499ad038520838c733cf1d214c953bc02f5f836dcb5ab3d3b0b1df88b560')
+  const random = hexToUint8Array('aabbccdd11223344aabbccdd11223344')
+  const npk1 = Note.computeNotePublicKey(mpk, random)
+  const npk2 = Note.computeNotePublicKey(mpk, random)
+  t.alike(npk1, npk2, 'same inputs should produce same NPK')
+})
+
+test('Note.computeNotePublicKey - different inputs produce different NPKs', (t) => {
+  const mpk1 = hexToUint8Array('0d40499ad038520838c733cf1d214c953bc02f5f836dcb5ab3d3b0b1df88b560')
+  const mpk2 = hexToUint8Array('2c59cd4733f911ba740da68fb7ba3b873f21daece4e3a105aef12d6414e54ebf')
+  const random = hexToUint8Array('aabbccdd11223344aabbccdd11223344')
+
+  const npkA = Note.computeNotePublicKey(mpk1, random)
+  const npkB = Note.computeNotePublicKey(mpk2, random)
+  t.not(uint8ArrayToHex(npkA), uint8ArrayToHex(npkB), 'different MPKs should produce different NPKs')
+
+  const random2 = hexToUint8Array('11223344aabbccdd11223344aabbccdd')
+  const npkC = Note.computeNotePublicKey(mpk1, random)
+  const npkD = Note.computeNotePublicKey(mpk1, random2)
+  t.not(uint8ArrayToHex(npkC), uint8ArrayToHex(npkD), 'different randoms should produce different NPKs')
 })
 
 test('Note.computeNullifier - engine test vectors', (t) => {

--- a/test/note.test.ts
+++ b/test/note.test.ts
@@ -95,3 +95,50 @@ test('Note.assertValidRandom - empty string', (t) => {
     Note.assertValidRandom('')
   }, 'should throw for empty string')
 })
+
+test('Note.computeNullifier - engine test vectors', (t) => {
+  const vectors = [
+    {
+      privateKey: '08ad9143ae793cdfe94b77e4e52bc4e9f13666966cffa395e3d412ea4e20480f',
+      position: 0,
+      nullifier: '0x03f68801f3ee2ed10178c162b4f7f1bd466bc9718f4f98175fc04934c5caba6e',
+    },
+    {
+      privateKey: '11299eb10424d82de500a440a2874d12f7c477afb5a3eb31dbb96295cdbcf165',
+      position: 12,
+      nullifier: '0x1aeadb64bf8faff93dfe26bcf0b2e2d0e9724293cc7a455f028b6accabee13b8',
+    },
+    {
+      privateKey: '09b57736523cda7412ddfed0d2f1f4a86d8a7e26de6b0638cd092c2a2b524705',
+      position: 6500,
+      nullifier: '0x091961ce11c244db49a25668e57dfa2b5ffb1fe63055dd64a14af6f2be58b0e7',
+    },
+  ]
+
+  for (const v of vectors) {
+    const result = Note.computeNullifier(
+      hexToUint8Array(v.privateKey),
+      BigInt(v.position)
+    )
+    t.is(uint8ArrayToHex(result), v.nullifier, `nullifier for position ${v.position}`)
+  }
+})
+
+test('Note.computeNullifier - determinism', (t) => {
+  const key = hexToUint8Array('08ad9143ae793cdfe94b77e4e52bc4e9f13666966cffa395e3d412ea4e20480f')
+  const result1 = Note.computeNullifier(key, 42n)
+  const result2 = Note.computeNullifier(key, 42n)
+  t.alike(result1, result2, 'same inputs should produce same nullifier')
+})
+
+test('Note.computeNullifier - different inputs produce different nullifiers', (t) => {
+  const key = hexToUint8Array('08ad9143ae793cdfe94b77e4e52bc4e9f13666966cffa395e3d412ea4e20480f')
+  const nullifier0 = Note.computeNullifier(key, 0n)
+  const nullifier1 = Note.computeNullifier(key, 1n)
+  t.not(uint8ArrayToHex(nullifier0), uint8ArrayToHex(nullifier1), 'different positions should produce different nullifiers')
+
+  const key2 = hexToUint8Array('11299eb10424d82de500a440a2874d12f7c477afb5a3eb31dbb96295cdbcf165')
+  const nullifierA = Note.computeNullifier(key, 0n)
+  const nullifierB = Note.computeNullifier(key2, 0n)
+  t.not(uint8ArrayToHex(nullifierA), uint8ArrayToHex(nullifierB), 'different keys should produce different nullifiers')
+})


### PR DESCRIPTION
- Fix poseidon hash inputs to always be 32 bytes
- Add `computeNullifier` static method to `Note`
- Add `computeNotePublicKey` static method to `Note`
- Point `types` field to `.ts` source for LSP resolution
- Add tests for all new methods and update existing hash vectors