### PR TITLE
chore: switch to padBytesLeftStrict and use workspace:* for bytes

### DIFF
--- a/src/notes/note.ts
+++ b/src/notes/note.ts
@@ -86,7 +86,7 @@ abstract class Note {
   static getHash (npk: Uint8Array, tokenHash: Uint8Array, value: bigint): Uint8Array {
     assertCryptoInitialized()
     const valueBytes = bigIntToBytes(value, 32)
-    return poseidon([padBytesLeft(npk, 32), padBytesLeft(tokenHash, 32), valueBytes])
+    return poseidon([padBytesLeft(npk, 32, { strict: true }), padBytesLeft(tokenHash, 32, { strict: true }), valueBytes])
   }
 
   /**
@@ -99,7 +99,7 @@ abstract class Note {
    */
   static computeNotePublicKey (masterPublicKey: Uint8Array, random: Uint8Array): Uint8Array {
     assertCryptoInitialized()
-    return poseidon([padBytesLeft(masterPublicKey, 32), padBytesLeft(random, 32)])
+    return poseidon([padBytesLeft(masterPublicKey, 32, { strict: true }), padBytesLeft(random, 32, { strict: true })])
   }
 
   /**

--- a/src/notes/token-utils.ts
+++ b/src/notes/token-utils.ts
@@ -11,7 +11,7 @@ import { SNARK_PRIME, TokenType } from './definitions'
  * @returns The token hash as a hex string (32 bytes, no 0x prefix)
  */
 function computeTokenHashERC20 (tokenAddress: Uint8Array): string {
-  return bytesToHex(padBytesLeft(tokenAddress, 32))
+  return bytesToHex(padBytesLeft(tokenAddress, 32, { strict: true }))
 }
 
 /**
@@ -22,8 +22,8 @@ function computeTokenHashERC20 (tokenAddress: Uint8Array): string {
  */
 function computeTokenHashNFT (tokenData: TokenData): string {
   const tokenTypeBytes = bigIntToBytes(BigInt(tokenData.tokenType), 32)
-  const tokenAddressBytes = padBytesLeft(tokenData.tokenAddress, 32)
-  const tokenSubIDBytes = padBytesLeft(tokenData.tokenSubID, 32)
+  const tokenAddressBytes = padBytesLeft(tokenData.tokenAddress, 32, { strict: true })
+  const tokenSubIDBytes = padBytesLeft(tokenData.tokenSubID, 32, { strict: true })
 
   // Combine: tokenType (32) + tokenAddress (32) + tokenSubID (32) = 96 bytes
   const combined = new Uint8Array(96)
@@ -91,10 +91,10 @@ function serializeTokenData (
 ): TokenData {
   const normalizedSubID = typeof tokenSubID === 'bigint'
     ? bigIntToBytes(tokenSubID, 32)
-    : padBytesLeft(tokenSubID, 32)
+    : padBytesLeft(tokenSubID, 32, { strict: true })
 
   return {
-    tokenAddress: padBytesLeft(tokenAddress, 20),
+    tokenAddress: padBytesLeft(tokenAddress, 20, { strict: true }),
     tokenType: Number(tokenType),
     tokenSubID: normalizedSubID,
   }
@@ -135,11 +135,11 @@ function deserializeTokenData (data: any): TokenData {
   }
 
   const tokenAddress = data.tokenAddress instanceof Uint8Array
-    ? padBytesLeft(data.tokenAddress, 20)
-    : padBytesLeft(hexToBytes(String(data.tokenAddress)), 20)
+    ? padBytesLeft(data.tokenAddress, 20, { strict: true })
+    : padBytesLeft(hexToBytes(String(data.tokenAddress)), 20, { strict: true })
 
   const tokenSubID = data.tokenSubID instanceof Uint8Array
-    ? padBytesLeft(data.tokenSubID, 32)
+    ? padBytesLeft(data.tokenSubID, 32, { strict: true })
     : bigIntToBytes(BigInt(data.tokenSubID), 32)
 
   return { tokenAddress, tokenType, tokenSubID }


### PR DESCRIPTION
## Context

Every \`padBytesLeft\` call site in this package pads to a fixed target — 32 for \`npk\` / \`masterPublicKey\` / \`random\` / \`tokenHash\` / \`tokenSubID\`, 20 for \`tokenAddress\` in its raw form — where an over-length input is always a bug rather than a tolerated case. Adding the new \`{ strict: true }\` option (railgun-reloaded/bytes#3) makes that contract explicit: malformed inputs now surface as \`ByteLengthExceeded\` at the boundary rather than passing through as silently-corrupted state into Poseidon hashes and downstream commitment data.

## Changes

- \`src/notes/note.ts\` — 4 sites (\`npk\`, \`tokenHash\`, \`masterPublicKey\`, \`random\`; all fixed 32 bytes)
- \`src/notes/token-utils.ts\` — 8 sites (\`tokenAddress\` at 20 or 32, \`tokenSubID\` at 32, \`tokenAddressBytes\` at 32)

## Behavior

Purely additive: every input today is already ≤ target (Ethereum addresses are 20 bytes max, sub-IDs are 32 max, public keys are fixed 32). No current call site changes behavior. Future malformed inputs that exceed the target now fail fast with a clear error.