### PR TITLE
chore: drop padBytesLeft wrappers around poseidon() calls

### DIFF
--- a/src/notes/note.ts
+++ b/src/notes/note.ts
@@ -1,4 +1,4 @@
-import { bigIntToBytes, padBytesLeft, stripHexPrefix } from '@railgun-reloaded/bytes'
+import { bigIntToBytes, stripHexPrefix } from '@railgun-reloaded/bytes'
 import { poseidon } from '@railgun-reloaded/cryptography'
 
 import { assertCryptoInitialized } from '../keys'
@@ -86,7 +86,7 @@ abstract class Note {
   static getHash (npk: Uint8Array, tokenHash: Uint8Array, value: bigint): Uint8Array {
     assertCryptoInitialized()
     const valueBytes = bigIntToBytes(value, 32)
-    return poseidon([padBytesLeft(npk, 32, { strict: true }), padBytesLeft(tokenHash, 32, { strict: true }), valueBytes])
+    return poseidon([npk, tokenHash, valueBytes])
   }
 
   /**
@@ -99,7 +99,7 @@ abstract class Note {
    */
   static computeNotePublicKey (masterPublicKey: Uint8Array, random: Uint8Array): Uint8Array {
     assertCryptoInitialized()
-    return poseidon([padBytesLeft(masterPublicKey, 32, { strict: true }), padBytesLeft(random, 32, { strict: true })])
+    return poseidon([masterPublicKey, random])
   }
 
   /**


### PR DESCRIPTION
## Context

Closes the loop on bhflm's [March 17 review note](https://github.com/railgun-reloaded/wallet-node/pull/14#pullrequestreview-3963845078) on #14: *"padding could be moved into cryptography so callers don't need to pad manually."* With **railgun-reloaded/cryptography#7** auto-padding inside `poseidon()`, the pre-pad wrappers in `note.ts` are redundant.

The `padBytesLeft` calls in `token-utils.ts` are around keccak256 / 20-byte address encoding — those stay; cryptography#7 only auto-pads the Poseidon path.

## Dependency

Blocked on **railgun-reloaded/cryptography#7**.