### PR TITLE
chore: add prepare script so git+https consumers build automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc --build",
     "clean": "tsc --build --clean",
+    "prepare": "tsc --build",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "pretest": "npm run build",


### PR DESCRIPTION
Without `prepare`, consumers that install this package via a git URL receive only the TypeScript source and no compiled `.js`. Adding `prepare: tsc --build` runs the TypeScript compiler at install time so the consumer ends up with the compiled output as if installed from npm. `prepare` runs automatically when installing git dependencies per npm's lifecycle scripts contract. Matching one-line PRs are going up across the other reloaded repos that need it.