### PR TITLE
build: emit type declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 *.js
+*.d.ts
 *.tsbuildinfo
 
 !eslint.config.js

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/railgun-reloaded/wallet-node#readme",
   "main": "src/index.js",
-  "types": "src/index.ts",
+  "types": "src/index.d.ts",
   "devDependencies": {
     "eslint": "^9.24.0",
     "typescript": "^5.8.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "@railgun-reloaded/tsconfig"
-  ]
+  ],
+  "compilerOptions": {
+    "declaration": true
+  }
 }


### PR DESCRIPTION
Emit `.d.ts` declarations so consumers get pre-resolved types instead of falling through to the `.ts` source. Co-located output, gitignored locally, regenerated via the existing `prepare: tsc --build` hook on install. Also corrects the `types` field which was pointing at the stale `.ts` source.