### PR TITLE
Drop removed cryptography init calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@noble/hashes": "^1.8.0",
         "@railgun-reloaded/0zk-addresses": "https://github.com/railgun-reloaded/0zk-addresses#dev",
         "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
-        "@railgun-reloaded/cryptography": "git+https://github.com/railgun-reloaded/cryptography.git#dev",
+        "@railgun-reloaded/cryptography": "github:railgun-reloaded/cryptography#dev",
         "@railgun-reloaded/eslint-config": "^1.1.0",
         "@railgun-reloaded/scanner": "https://github.com/railgun-reloaded/scanner#dev",
         "@railgun-reloaded/tsconfig": "^1.2.0",
@@ -1040,13 +1040,44 @@
     },
     "node_modules/@railgun-reloaded/cryptography": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/railgun-reloaded/cryptography.git#9d381d2dbd22ffaa6c887ba8e3e8a4a87390b94f",
+      "resolved": "git+ssh://git@github.com/railgun-reloaded/cryptography.git#412c448eecbfef08788053fd6a1b3ccf5b6ecbe6",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "^1.8.0",
+        "@iden3/js-crypto": "^1.3.3",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
-        "circomlibjs": "^0.1.7",
         "poseidon-lite": "^0.3.0"
+      }
+    },
+    "node_modules/@railgun-reloaded/cryptography/node_modules/@iden3/js-crypto": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-1.3.3.tgz",
+      "integrity": "sha512-rtFItB3B61yjXmfvNAjMg4y10St15Rqm5K/ZNnYEy7TJQRAu249sIcvkQw0mKevw/g2uObk7Hv76DPegAV6xDw==",
+      "peerDependencies": {
+        "@noble/hashes": "2.2.0"
+      }
+    },
+    "node_modules/@railgun-reloaded/cryptography/node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@railgun-reloaded/cryptography/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@railgun-reloaded/eslint-config": {
@@ -5768,13 +5799,32 @@
       "integrity": "sha512-mY5xNq3DPbVLHCMoUPfo360o8fb055yqCIxIKSr+P9U1AFReX5+zlPLE0t1xbb3bkCjiEVkCC7iiishCoeUZvQ=="
     },
     "@railgun-reloaded/cryptography": {
-      "version": "git+ssh://git@github.com/railgun-reloaded/cryptography.git#9d381d2dbd22ffaa6c887ba8e3e8a4a87390b94f",
+      "version": "git+ssh://git@github.com/railgun-reloaded/cryptography.git#412c448eecbfef08788053fd6a1b3ccf5b6ecbe6",
       "from": "@railgun-reloaded/cryptography@git+https://github.com/railgun-reloaded/cryptography.git#dev",
       "requires": {
-        "@noble/hashes": "^1.8.0",
+        "@iden3/js-crypto": "^1.3.3",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
         "@railgun-reloaded/bytes": "git+https://github.com/railgun-reloaded/bytes.git#dev",
-        "circomlibjs": "^0.1.7",
         "poseidon-lite": "^0.3.0"
+      },
+      "dependencies": {
+        "@iden3/js-crypto": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@iden3/js-crypto/-/js-crypto-1.3.3.tgz",
+          "integrity": "sha512-rtFItB3B61yjXmfvNAjMg4y10St15Rqm5K/ZNnYEy7TJQRAu249sIcvkQw0mKevw/g2uObk7Hv76DPegAV6xDw==",
+          "requires": {}
+        },
+        "@noble/ciphers": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+          "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="
+        },
+        "@noble/hashes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+          "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="
+        }
       }
     },
     "@railgun-reloaded/eslint-config": {

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -2,7 +2,7 @@ import type * as Ed25519 from '@noble/ed25519'
 import { sha256, sha512 } from '@noble/hashes/sha2'
 import { randomBytes } from '@noble/hashes/utils'
 import { bigIntToBytes, bytesToBigInt } from '@railgun-reloaded/bytes'
-import { eddsa, initCircomlib, initializeEddsa, poseidon } from '@railgun-reloaded/cryptography'
+import { eddsa, poseidon } from '@railgun-reloaded/cryptography'
 
 import { xorBytesInPlace } from './encoding.js'
 
@@ -58,18 +58,12 @@ function getEd25519 (): Ed25519Module {
 }
 
 /**
- * Initializes the cryptography libraries required for the application.
- * This function sets up Circomlib and EDDSA cryptographic primitives and sets the
+ * Initializes the asynchronous cryptography dependencies (ed25519) and sets the
  * cryptoInitialized flag, enabling all functions guarded by assertCryptoInitialized().
- * @throws {Error} Throws an error if EDDSA fails to initialize.
  * @returns A promise that resolves when the cryptography libraries are successfully initialized.
  */
 const initializeCryptographyLibs = async () => {
   await loadEd25519()
-  await initCircomlib('pure')
-  await initCircomlib('wasm')
-  await initializeEddsa()
-  if (typeof eddsa === 'undefined') { throw new Error('EDDSA failed to initialize.') }
   cryptoInitialized = true
 }
 


### PR DESCRIPTION
Adapts to `@railgun-reloaded/cryptography` removing its asynchronous initialization API. Poseidon and EdDSA are synchronous there now, so `initCircomlib` and `initializeEddsa` no longer exist.

`initializeCryptographyLibs()` now only loads ed25519 (still async) and sets the initialized flag; the Poseidon/EdDSA init calls are removed. Key derivation, signing, and verification are unchanged and byte-identical.

Depends on the cryptography browser/mobile change landing on `dev` first (it removes the init API). CI here stays red until that merges; the `#dev` dependency pin is intentionally left unchanged.